### PR TITLE
docling-client

### DIFF
--- a/.github/workflows/docling-client.yml
+++ b/.github/workflows/docling-client.yml
@@ -1,0 +1,32 @@
+name: Docling Client
+
+on:
+  pull_request:
+    paths:
+      - 'docling-client/**'
+      - '.github/workflows/docling-client.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docling-client/**'
+      - '.github/workflows/docling-client.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docling-client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docling-client/package-lock.json
+      - run: npm ci
+      - run: npm run check

--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ The [docling-core](docling-core) package mirrors type definitions and utility fu
 ## Docling Components
 
 The [docling-components](docling-components) package provides web components for displaying Docling JSON output.
+
+## Docling Client
+
+The [docling-client](docling-client) package is the official TypeScript client
+for Docling Serve and managed services implementing its API. It is modeled after
+the official python client.

--- a/docling-client/.prettierignore
+++ b/docling-client/.prettierignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/docling-client/.prettierrc
+++ b/docling-client/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "printWidth": 88,
+  "quoteProps": "as-needed",
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "useTabs": false
+}

--- a/docling-client/PYTHON_CLIENT_PARITY.md
+++ b/docling-client/PYTHON_CLIENT_PARITY.md
@@ -1,0 +1,360 @@
+# Python client parity
+
+This document compares `@docling/docling-client` with Docling Python 2.115.0
+at commit `f4380498`, specifically:
+
+- `DoclingServiceClient`
+- `AsyncDoclingServiceClient`
+- `ConversionJob` and `AsyncConversionJob`
+- the shared request, response, watcher, scheduler, and error contracts
+
+TypeScript is naturally asynchronous, so Python's synchronous and asynchronous
+facades map to one Promise/`AsyncIterable` API. No Python service-client
+capability is deferred in this package. Language-specific adaptations and
+additional TypeScript capabilities are documented after the parity tables.
+
+## Client configuration
+
+| Python constructor capability | TypeScript                               | Parity notes                                                                                                  |
+| ----------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Service URL                   | `baseUrl`                                | Both normalize trailing slashes and reject `/v1`, query, and fragment components.                             |
+| API key                       | `apiKey`                                 | HTTP uses `X-Api-Key`; WebSocket uses the query parameter and also the header in Node.                        |
+| Default conversion options    | `options`                                | Deep-copied at construction; per-call merge is shallow.                                                       |
+| Status watcher                | `statusWatcher`                          | `websocket` default or `polling`.                                                                             |
+| WebSocket polling fallback    | `webSocketFallbackToPoll`                | Enabled by default.                                                                                           |
+| Poll server wait              | `pollServerWaitSeconds`                  | Five seconds by default.                                                                                      |
+| Poll client interval          | `pollClientIntervalMs`                   | Defaults to the server-wait duration.                                                                         |
+| Job timeout                   | `jobTimeoutMs`                           | Five minutes by default.                                                                                      |
+| Conversion concurrency        | `maxConcurrency`                         | Eight by default; valid range 1–512.                                                                          |
+| HTTP retries                  | `httpRetries`                            | Three by default.                                                                                             |
+| HTTP timeout                  | `httpTimeoutMs`                          | Fetch has one total per-attempt timeout; Python/httpx exposes distinct connect and read/write/pool timeouts.  |
+| HTTP backoff                  | `httpBackoffBaseMs`                      | One second by default.                                                                                        |
+| Artifact timeout and size     | `artifactDownload.timeoutMs`, `maxBytes` | Same 60-second and 512-MiB defaults.                                                                          |
+| Private artifact override     | `artifactDownload.allowPrivateUrls`      | Public TypeScript option; Python keeps its equivalent internal.                                               |
+| Owned resource cleanup        | `close()`                                | TypeScript close is asynchronous, idempotent, closes an injected transport once, and prevents later requests. |
+
+`fetch`, `transport`, `webSocketFactory`, `artifactDownloader`, and artifact
+DNS/fetch injection are TypeScript extensions.
+
+## Public operations
+
+| Capability               | Python                          | TypeScript                             | Result/behavior                                                                                                       |
+| ------------------------ | ------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Health                   | `health()`                      | `health()`                             | No retries; validates `HealthCheckResponse`, including the default `"ok"` status.                                     |
+| Version                  | `version()`                     | `version()`                            | No retries; requires an object response.                                                                              |
+| Close                    | `close()` / `aclose()`          | `close()`                              | Resource cleanup.                                                                                                     |
+| Convert one              | sync `convert()`                | async `convert()`                      | High-level `ConversionResult`; presigned-first, safe materialization, narrow in-body fallback, Markdown+JSON default. |
+| Convert many             | sync `convert_all()`            | async iterable `convertAll()`          | One task per source, lazy bounded scheduling, input order, per-source failure isolation.                              |
+| Submit one               | `submit()`                      | `submitSource()` or `submit()`         | Typed job; explicit in-body target resolves to `ConversionResult`.                                                    |
+| URL convenience          | HTTP source model               | `submitUrl()`                          | Adds separate source-fetch headers.                                                                                   |
+| Base64 convenience       | file source model               | `submitFile()`                         | Unified base64 source.                                                                                                |
+| Local/binary convenience | `Path` / `DocumentStream`       | path string / `submitBinary()`         | Multipart where the route can represent the target; unified base64 otherwise.                                         |
+| Batch connectors         | `submit_batch()`                | `submitBatch()`                        | Remote source enumeration and remote/presigned target.                                                                |
+| Output-format override   | `output_formats=`               | `outputFormats`                        | Overrides merged `to_formats` for submit/batch convenience calls.                                                     |
+| Submit chunk job         | `submit_chunk()`                | `submitChunk*()`                       | Hybrid or hierarchical job.                                                                                           |
+| Convert and chunk        | sync `chunk()`                  | async `chunk()`                        | Combined service conversion and chunking.                                                                             |
+| Per-item fan-out         | `submit_and_retrieve_each()`    | `submitAndRetrieveEach()`              | Lazy bounded full-lifecycle scheduling; completion or input order.                                                    |
+| Deprecated fan-out name  | `submit_and_retrieve_many()`    | `submitAndRetrieveMany()`              | Alias retained.                                                                                                       |
+| Attach to task           | internal job construction       | `job()`                                | TypeScript exposes attachment publicly.                                                                               |
+| Poll                     | job `poll()`                    | client/job `poll()`                    | `wait=0` default; task-not-found mapping.                                                                             |
+| Watch                    | job `watch()`                   | client/job `watch()`                   | WebSocket handshake/reconnect/fallback or polling.                                                                    |
+| Wait                     | job `result()` waits internally | job `wait()` and `result()`            | TypeScript exposes terminal wait separately.                                                                          |
+| Fetch typed result       | job `result()`                  | job `getResult()` / `result()`         | Target-specific loader.                                                                                               |
+| Fetch raw result         | internal helpers                | `getRawResult()` / `getBinaryResult()` | TypeScript extension for integrations.                                                                                |
+
+The Python asynchronous facade intentionally omits high-level
+`convert()`, `convert_all()`, and `chunk()` methods. TypeScript includes them
+because async is its native execution model.
+
+## Sources
+
+| Source                               | Ordinary conversion/chunk | Batch | Notes                                                                      |
+| ------------------------------------ | ------------------------- | ----- | -------------------------------------------------------------------------- |
+| HTTP(S)                              | Yes                       | Yes   | Headers are preserved; ordinary conversion rejects `.zip` URLs.            |
+| Base64 file                          | Yes                       | No    | JSON `FileSource`.                                                         |
+| Local path                           | Yes, Node                 | No    | Read lazily when normalized, then multipart or base64 depending on target. |
+| `Blob` / `ArrayBuffer` / typed array | Yes                       | No    | TypeScript extension for Node/browser integrations.                        |
+| S3                                   | No                        | Yes   | Endpoint, SSL flag, keys, bucket, prefix, enumeration limit.               |
+| Azure Blob                           | No                        | Yes   | Account, container, connection string, prefix, enumeration limit.          |
+| Google Cloud Storage                 | No                        | Yes   | Bucket, prefix, project/ADC, optional service-account object.              |
+| Google Drive                         | No                        | Yes   | Path, token/refresh token, credentials path/object.                        |
+| Generic connector                    | No                        | Yes   | Forward-compatible `kind` plus connector fields.                           |
+
+TypeScript mirrors Python's extension-to-input-format map, including Office
+templates/macros, images, XML variants, `tar.gz`, audio/video, email, EPUB, and
+Box Note. Unknown extensions use the same PDF fallback. Local multipart MIME is
+inferred from the filename when known.
+
+## Targets and target-specific results
+
+| Target               | Ordinary          | Batch | TypeScript job result                                         |
+| -------------------- | ----------------- | ----- | ------------------------------------------------------------- |
+| In body              | Yes               | No    | `ConversionResult`                                            |
+| ZIP                  | Yes               | No    | `RawServiceResult`                                            |
+| Presigned URL        | Yes               | Yes   | `PresignedUrlConvertResponse` with documents/artifacts/counts |
+| S3                   | Yes               | Yes   | outcome counts                                                |
+| Azure Blob           | Yes               | Yes   | outcome counts                                                |
+| Google Cloud Storage | Yes               | Yes   | outcome counts                                                |
+| Google Drive         | Yes               | Yes   | outcome counts                                                |
+| Generic              | Python batch only | Yes   | outcome counts                                                |
+| Put URL              | Wire model only   | No    | TypeScript low-level ordinary-target extension                |
+
+`RemoteTargetResponse` is the clearer TypeScript alias for Python's historical
+`PresignedUrlConvertDocumentResponse` counts-only name.
+
+When a binary/local source uses Put or a storage target, TypeScript uses the
+unified base64 endpoint rather than dropping target coordinates in the
+multipart `target_type` field. This is stricter and more functional than the
+overbroad Python multipart target annotation.
+
+## Conversion options and limits
+
+The explicit TypeScript option surface covers every field in Python
+`ConvertDocumentsOptions`:
+
+- `from_formats`, `to_formats`, `pipeline`, `page_range`
+- `image_export_mode`, `include_images`, `include_page_images`, `images_scale`
+- `do_ocr`, `force_ocr`, `ocr_engine`, `ocr_preset`, `ocr_lang`,
+  `ocr_custom_config`
+- `pdf_backend`
+- `table_mode`, `table_cell_matching`, `do_table_structure`
+- `do_code_enrichment`, `do_formula_enrichment`
+- `do_picture_classification`, `do_picture_description`,
+  `do_chart_extraction`, `picture_description_area_threshold`
+- the deprecated `picture_description_local`, `picture_description_api`,
+  `vlm_pipeline_model`, `vlm_pipeline_model_local`, and
+  `vlm_pipeline_model_api`
+- VLM, picture-description, code/formula, table-structure, layout, and
+  picture-classification preset/custom-config pairs
+- `document_timeout`, `abort_on_error`, and Markdown page-break placeholder
+
+Known enums, page ranges, primitive shapes, and nested option object boundaries
+are checked locally. Legacy VLM/picture-description model objects and the
+Python model's preset/custom and legacy/new mutual-exclusion rules are also
+validated before submission, including the exact Docling Core picture
+classification labels. The string index accepts options introduced by a newer
+managed service without forcing a client release.
+
+Constructor options are copied. Per-call fields replace constructor fields at
+the top level; `undefined` means no override and `null` clears an optional
+default. Neither caller object is mutated.
+
+High-level limits match Python:
+
+- `maxNumPages` caps the effective page-range end.
+- `pageRange` overrides the option's page range.
+- `maxFileSize` preflights local, base64, and binary sources.
+- Oversized input becomes a skipped result unless `raisesOnError` is enabled.
+- Remote URL size remains unknown before service fetch.
+
+TypeScript restricts limit values to safe integers, which is stricter than
+Python's unbounded integer type.
+
+## Chunking
+
+Both clients call the dedicated async routes:
+
+```text
+POST /v1/chunk/hybrid/source/async
+POST /v1/chunk/hybrid/file/async
+POST /v1/chunk/hierarchical/source/async
+POST /v1/chunk/hierarchical/file/async
+```
+
+Both support:
+
+- conversion options;
+- hybrid `max_tokens`, `tokenizer`, and `merge_peers`;
+- shared `use_markdown_tables`, `use_markdown_images`, `image_placeholder`,
+  and `include_raw_text`;
+- `include_converted_doc`;
+- in-body `ChunkDocumentResponse`;
+- URL/base64/local/binary input.
+
+TypeScript additionally exposes multi-source JSON chunk jobs, all chunker
+options directly, and callbacks on JSON chunk requests. The multipart Serve
+route has no callback form field, so the client rejects callbacks there rather
+than silently discarding them. Known chunk-option primitives are validated
+locally, and the route-selected chunker discriminator cannot be overridden by
+an untyped payload.
+
+`OutputFormat` still contains `"chunks"` because the Python enum does. That
+value does not select a Serve chunk task; callers use the chunk routes.
+
+## Jobs, watchers, and scheduling
+
+| Behavior                  | Python                                             | TypeScript                                                                                                       |
+| ------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Initial task data         | task id, submitted time, status, position          | Same                                                                                                             |
+| `status` property         | status string                                      | Full cached `TaskStatusResponse`                                                                                 |
+| Queue position            | Yes                                                | Yes                                                                                                              |
+| Done state                | success/failure                                    | Same                                                                                                             |
+| Poll default              | `wait=0`                                           | Same                                                                                                             |
+| Default watch             | WebSocket                                          | Same                                                                                                             |
+| WebSocket auth            | query plus header                                  | Query plus header in Node; browser WebSocket APIs prohibit custom headers, so browsers use the query credential. |
+| Serve handshake           | sends `"next"` after nonterminal update            | Same                                                                                                             |
+| Transport reconnects      | Three with exponential delays                      | Same                                                                                                             |
+| Protocol/server error     | no transport reconnect                             | Same                                                                                                             |
+| Poll fallback             | configurable                                       | Same                                                                                                             |
+| Poll cadence              | minimum client interval when server returns early  | Same                                                                                                             |
+| Terminal cached `watch()` | contacts watcher and yields current service status | Same                                                                                                             |
+| Cancellation              | coroutine/task cancellation                        | `AbortSignal`                                                                                                    |
+
+WebSockets and pending event waits are closed on success, error, timeout,
+cancellation, callback failure, and early iterator return. A server error
+falls back immediately when configured; only transport/connection failures
+consume reconnect attempts.
+
+Source normalization is cancellation-aware as well: pre-aborted calls do no
+file I/O, Node path reads receive the caller signal, and binary materialization
+checks cancellation before and after asynchronous reads.
+
+Both schedulers:
+
+- validate concurrency from 1 through 512;
+- start lazily and bound complete submit/watch/result lifecycles;
+- support completion order or input order;
+- isolate ordinary item failures as values;
+- cancel active work and close the input iterator when the consumer stops;
+- switch fan-out waits above 64 in-flight jobs from WebSockets to polling.
+
+Python's `submit_and_retrieve_each()` default is always eight even if the
+client's conversion concurrency differs; TypeScript matches that behavior.
+TypeScript also accepts `AsyncIterable`, preserves generic metadata, and
+provides compile-time-correct auto-target result unions.
+
+## HTTP policy
+
+The built-in transport matches Python:
+
+| Condition                                | Policy                                   |
+| ---------------------------------------- | ---------------------------------------- |
+| HTTP 500 or 502                          | Retry every method, exponential backoff  |
+| HTTP 429 or 503 with valid `Retry-After` | Retry after numeric seconds or HTTP date |
+| HTTP 429 or 503 without valid header     | Do not retry                             |
+| Network/transport failure                | Retry GET, HEAD, and OPTIONS only        |
+| Caller cancellation                      | Never retry                              |
+| Health/version                           | Zero retries                             |
+| Successful service response              | Exactly HTTP 200                         |
+
+Retried response bodies are canceled, zero-delay retries do not sleep, and the
+exhausted error preserves status and service detail. The Fetch implementation
+uses one total timeout per attempt instead of httpx's separate phase timeouts.
+
+A custom `DoclingTransport` replaces the complete built-in HTTP policy. That
+is an integration boundary, not a partial hook: the host owns response status,
+headers, binary handling, retries, quotas, timeout, and error mapping.
+
+## Error mapping
+
+| Python error                             | TypeScript                           |
+| ---------------------------------------- | ------------------------------------ |
+| `DoclingServiceClientError`              | `DoclingError`                       |
+| `ServiceError`                           | `DoclingServiceError`                |
+| generic non-retryable HTTP service error | `DoclingHttpError`                   |
+| `ServiceUnavailableError`                | `DoclingServiceUnavailableError`     |
+| `ResponseSchemaMismatchError`            | `DoclingResponseSchemaMismatchError` |
+| `UsageLimitExceededError`                | `DoclingUsageLimitExceededError`     |
+| `TaskExecutionError`                     | `DoclingTaskError`                   |
+| `TaskTimeoutError`                       | `DoclingTimeoutError`                |
+| `TaskNotFoundError`                      | `DoclingTaskNotFoundError`           |
+| `ResultNotReadyError`                    | `DoclingResultNotReadyError`         |
+| `ResultExpiredError`                     | `DoclingResultExpiredError`          |
+| `ArtifactDownloadError`                  | `DoclingArtifactDownloadError`       |
+| `ConversionError`                        | `DoclingConversionError`             |
+| `BatchConversionError`                   | `DoclingBatchConversionError`        |
+
+All service-originated TypeScript errors share `DoclingServiceError`, including
+HTTP, availability, quota, and schema failures. Quota errors preserve the
+service message, current usage, and limit.
+
+Result lookup implements all Python branches:
+
+- `"Task not found."` becomes task-not-found;
+- missing result plus cached failure becomes authoritative task failure;
+- missing result plus cached success becomes expired;
+- missing result before a terminal state becomes not-ready;
+- unexpected 404 detail remains a service error with status/detail;
+- terminal task failure still fetches the result to recover structured failure
+  information.
+
+## Response and artifact validation
+
+TypeScript validates the complete service boundary it consumes:
+
+- task id/type/status, position, progress counts, and structured failure;
+- converted document wrapper, status, errors, timings, confidence, and
+  processing time;
+- every chunk and per-document chunk result;
+- every presigned count, document item, artifact type, MIME, URI, error, and
+  timing;
+- task-failure category, phase, retryability, and string details;
+- health/version and binary metadata.
+
+The exported `FailureCategory`, `DoclingComponentType`, `ProfilingScope`,
+`QualityGrade`, and `ConfidenceScores` types mirror the corresponding Python
+wire contracts; the public result types use those structured definitions
+rather than unbounded strings or generic records.
+
+Python Pydantic reconstructs and validates the complete version-pinned
+`DoclingDocument`. TypeScript intentionally validates the document identity
+(`schema_name` and `name`) at the client boundary and leaves the remaining
+version-specific JSON generic. Applications can parameterize
+`DoclingClient<TDocument>` with their installed
+`@docling/docling-core` type. This avoids coupling the transport package to a
+stale or mismatched core schema.
+
+Presigned materialization otherwise matches Python and adds stricter checks:
+
+- dedicated header-free artifact transport;
+- public-address SSRF protection on every redirect;
+- all DNS answers must be globally routable, rather than checking one answer;
+- five redirect, timeout, and compressed-size limits;
+- bounded streaming ZIP inflation, uncompressed-size and entry-count limits;
+- path traversal rejection;
+- exactly one top-level Docling JSON document;
+- image MIME/signature validation before embedding.
+
+## TypeScript-only capabilities
+
+These are deliberately richer than the Python client:
+
+- `AbortSignal` on submissions, polling, watching, result fetching, artifact
+  download, and fan-out;
+- injectable HTTP transport/fetch, WebSocket factory, artifact downloader,
+  artifact fetch, DNS resolver, sleep function, and private-URL policy;
+- public task attachment and raw JSON/binary result methods;
+- full cached status objects and a public `wait()` method;
+- browser `Blob`, `ArrayBuffer`, typed-array, and base64 sources;
+- `AsyncIterable` fan-out;
+- low-level Put target support;
+- complete target-aware generic return types and typed auto-target unions;
+- batch callbacks and output-format override;
+- full chunk options, multi-source JSON chunking, callbacks, and
+  `include_converted_doc`;
+- stricter all-address artifact DNS validation and bounded bundle inflation;
+- external-target binary submission that preserves coordinates by choosing the
+  unified JSON route;
+- a version-neutral document boundary that can be parameterized with any
+  installed Docling Core schema.
+
+## Deliberate language adaptations
+
+These are implemented adaptations, not postponed features:
+
+- There is no blocking TypeScript facade; all I/O returns Promises or async
+  iterables.
+- TypeScript `ConversionResult` carries a plain document JSON object, input
+  descriptor, status, errors, timings, confidence, and processing time.
+  Python additionally constructs a lightweight `InputDocument` and empty
+  `AssembledUnit`, which are Python runtime classes with no meaningful
+  JavaScript equivalent.
+- On a failed/skipped result or missing JSON, TypeScript constructs a minimal
+  `{schema_name: "DoclingDocument", name}` document, matching Python's
+  non-null empty-document behavior.
+- Fetch exposes a total attempt timeout rather than distinct socket phases.
+- Node can enforce DNS-based artifact SSRF checks directly. Browser callers
+  must inject a trusted resolver/policy because browser APIs intentionally hide
+  DNS answers.
+- The package uses camelCase for client control arguments and preserves
+  snake_case for Serve wire models.

--- a/docling-client/README.md
+++ b/docling-client/README.md
@@ -1,0 +1,367 @@
+# Docling Client
+
+`@docling/docling-client` is the official TypeScript client for
+[Docling Serve](https://github.com/docling-project/docling-serve) and managed
+Docling services implementing the same API, including IBM-hosted Docling.
+
+It is a remote client. Document conversion, OCR, table extraction, enrichment,
+and chunking run in the service; the package submits work, follows task state,
+retrieves results, and safely materializes artifacts.
+
+## Install
+
+```sh
+npm install @docling/docling-client
+```
+
+Node.js 18 or newer is required. URL and base64 requests work in Node and
+browsers. Node additionally supports local paths. Browser applications using
+the default presigned-artifact path must provide a trusted DNS resolver through
+`artifactDownload.resolver`, or explicitly opt into their own URL policy with
+`allowPrivateUrls`; browsers do not expose DNS answers needed by the default
+SSRF check.
+
+## Configure
+
+```ts
+import { DoclingClient } from '@docling/docling-client';
+
+const client = new DoclingClient({
+  baseUrl: process.env.DOCLING_URL!,
+  apiKey: process.env.DOCLING_API_KEY,
+  options: {
+    do_ocr: true,
+    table_mode: 'accurate',
+  },
+  statusWatcher: 'websocket',
+  webSocketFallbackToPoll: true,
+  jobTimeoutMs: 15 * 60_000,
+  maxConcurrency: 8,
+  httpRetries: 3,
+  httpTimeoutMs: 60_000,
+});
+```
+
+The base URL is the service root, without `/v1`, a query, or a fragment.
+`X-Api-Key` is sent when `apiKey` is set. Per-call service headers override
+constructor headers.
+
+## Convert
+
+`convert()` is the high-level, Python-compatible path. It tries a presigned
+artifact target first, narrowly falls back to an in-body result when artifact
+storage is unavailable, requests Markdown plus Docling JSON by default, and
+returns a `ConversionResult`.
+
+```ts
+const result = await client.convert('https://example.org/manual.pdf', {
+  options: {
+    do_ocr: true,
+    table_mode: 'accurate',
+    include_images: true,
+  },
+  maxNumPages: 100,
+  maxFileSize: 100 * 1024 * 1024,
+  pageRange: [1, 20],
+  raisesOnError: true,
+});
+
+console.log(result.status);
+console.log(result.document);
+console.log(result.errors);
+```
+
+Sources accepted by high-level calls are:
+
+- HTTP(S) URL strings, `URL`, or `{kind: "http"}` sources, including
+  source-fetch headers;
+- Node filesystem paths;
+- `{data, filename, contentType}` using `Blob`, `ArrayBuffer`, or typed arrays;
+- base64 `{kind: "file", filename, base64_string}` sources.
+
+ZIP URLs are rejected on ordinary conversion routes. Local and binary inputs
+use multipart upload for in-body, ZIP, and presigned targets. External targets
+use the unified base64 request so their complete credentials and coordinates
+are preserved.
+
+`convertAll()` lazily runs one complete task per source with bounded
+concurrency, preserves input order, and turns individual failures into failed
+`ConversionResult` values without stopping unrelated work:
+
+```ts
+for await (const result of client.convertAll(urls, {
+  maxConcurrency: 16,
+})) {
+  console.log(result.input.filename, result.status);
+}
+```
+
+## Submit jobs and choose a target
+
+`submitSource()` mirrors Python's job-oriented `submit()`. Convenience methods
+are available for URL, base64, and binary inputs.
+
+```ts
+const job = await client.submitUrl(
+  'https://example.org/manual.pdf',
+  { to_formats: ['md', 'json'] },
+  { target: { kind: 'inbody' } }
+);
+
+for await (const status of job.watch()) {
+  console.log(status.task_status, status.task_position);
+}
+
+const result = await job.result();
+console.log(result.document);
+```
+
+Target-specific results are statically typed:
+
+| Target                                                               | Result                                                                      |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| omitted                                                              | presigned response, or `ConversionResult` after the narrow in-body fallback |
+| `{kind: "inbody"}`                                                   | `ConversionResult`                                                          |
+| `{kind: "zip"}`                                                      | `RawServiceResult` with lossless `Uint8Array` content                       |
+| `{kind: "presigned_url"}`                                            | per-document artifacts and outcome counts                                   |
+| S3, Azure Blob, Google Cloud Storage, Google Drive, or low-level Put | outcome counts                                                              |
+
+S3, Azure, GCS, Drive, generic connector, callback, and Put payloads can carry
+credentials. Treat request bodies and logs accordingly.
+
+## Batch connectors
+
+The batch route enumerates documents from remote connectors and writes to a
+presigned or storage target:
+
+```ts
+const job = await client.submitBatch(
+  {
+    sources: [
+      {
+        kind: 's3',
+        endpoint: 's3.us-east-1.amazonaws.com',
+        access_key: process.env.S3_ACCESS_KEY!,
+        secret_key: process.env.S3_SECRET_KEY!,
+        bucket: 'incoming-documents',
+        key_prefix: 'manuals/',
+      },
+    ],
+    target: { kind: 'presigned_url' },
+    callbacks: [
+      {
+        url: 'https://workflow.example.com/docling-progress',
+        headers: { authorization: `Bearer ${process.env.CALLBACK_TOKEN}` },
+      },
+    ],
+  },
+  { outputFormats: ['json', 'md'] }
+);
+
+const result = await job.result();
+```
+
+Batch sources support HTTP, S3, Azure Blob, GCS, Google Drive, and
+forward-compatible generic connectors. Batch targets support presigned
+artifacts, those storage systems, and generic connectors. File, in-body, ZIP,
+and Put targets are rejected on the batch route, matching the Python client.
+
+## Convert and chunk
+
+Chunk endpoints convert and chunk in one service task:
+
+```ts
+const result = await client.chunk('https://example.org/manual.pdf', {
+  chunker: 'hybrid',
+  convert_options: {
+    do_ocr: true,
+    table_mode: 'accurate',
+  },
+  chunking_options: {
+    max_tokens: 384,
+    tokenizer: 'sentence-transformers/all-MiniLM-L6-v2',
+    merge_peers: true,
+    include_raw_text: true,
+    use_markdown_tables: true,
+    use_markdown_images: true,
+  },
+  include_converted_doc: true,
+});
+
+console.log(result.chunks[0]?.text);
+console.log(result.documents[0]?.content.json_content);
+```
+
+The Python-shaped overload is also supported:
+
+```ts
+const result = await client.chunk(
+  'https://example.org/manual.pdf',
+  'hierarchical',
+  { do_ocr: true },
+  { includeConvertedDoc: true }
+);
+```
+
+Use `submitChunk()`, `submitChunkUrl()`, `submitChunkFile()`, or
+`submitChunkBinary()` when a job handle is needed. JSON chunk requests support
+multiple sources, callbacks, all chunker options, and
+`include_converted_doc`. Multipart chunk routes accept one file and do not
+support callbacks.
+
+Although `chunks` is a member of Docling's general `OutputFormat` enum, Serve
+chunking is selected through
+`/v1/chunk/{hybrid|hierarchical}/{source|file}/async`, not by setting
+`to_formats: ["chunks"]` on a normal conversion.
+
+## Fan-out
+
+`submitAndRetrieveEach()` accepts `Iterable` and `AsyncIterable` inputs, keeps
+at most `maxInFlight` full task lifecycles active, and yields completion order
+by default:
+
+```ts
+for await (const [item, outcome] of client.submitAndRetrieveEach(items, {
+  maxInFlight: 8,
+  ordered: false,
+})) {
+  if (outcome instanceof Error) {
+    console.error(item.metadata, outcome);
+  } else {
+    console.log(item.metadata, outcome);
+  }
+}
+```
+
+Omitting `target` retains the correctly typed presigned-or-in-body result.
+When more than 64 jobs are in flight, the client uses polling for those waits
+instead of opening more WebSockets. `submitAndRetrieveMany()` remains as a
+deprecated alias.
+
+## Task lifecycle
+
+`DoclingJob` exposes:
+
+- `taskId`, `submittedAt`, `queuePosition`, `done`, and the full cached
+  `TaskStatusResponse` through `status`;
+- `poll()`, `watch()`, `wait()`, `getResult()`, and `result()`.
+
+`client.job(taskId, status?, loader?)` attaches to existing work. WebSocket
+watching is the default, authenticates with the query parameter and, in Node,
+also `X-Api-Key`, implements Serve's `next` handshake, reconnects transport
+failures up to three times, and can fall back to long polling. Polling uses
+`GET /v1/status/poll/{task_id}?wait=...`.
+
+All waits accept `AbortSignal`. Result lookup distinguishes an unknown task, a
+not-yet-ready result, an expired terminal result, and authoritative task
+failure.
+
+## Retries and errors
+
+The default `FetchTransport` matches the Python retry policy:
+
+- HTTP 500 and 502 retry for every method with exponential backoff;
+- HTTP 429 and 503 retry only with a valid `Retry-After`;
+- transport failures retry only for GET, HEAD, and OPTIONS;
+- caller cancellation is never retried;
+- health and version calls use zero retries.
+
+All service-originated failures derive from `DoclingServiceError`.
+Specialized errors cover HTTP responses, exhausted/unavailable service,
+usage limits, response-schema mismatch, task execution, task timeout, task
+not-found, result-not-ready, result-expired, artifact download, and
+high-level conversion failure.
+
+## Presigned artifact safety
+
+High-level conversion can materialize a JSON artifact or a resource bundle.
+The downloader:
+
+- never forwards Docling service headers to artifact hosts;
+- allows only HTTP(S), resolves every DNS address, and rejects any non-global
+  address unless explicitly configured otherwise;
+- revalidates every redirect, with a five-redirect default;
+- enforces timeout, compressed-download, uncompressed-bundle, and entry-count
+  limits;
+- validates ZIP paths, requires exactly one top-level Docling JSON file, and
+  validates referenced image MIME signatures before embedding data URIs.
+
+Download or reconstruction failure becomes a failed `ConversionResult`, which
+lets `convertAll()` continue. Caller cancellation still propagates.
+
+## Conversion options
+
+`ConvertDocumentsOptions` explicitly types the current Python/Serve fields:
+format selection, pipeline, page range, OCR, PDF backend, table extraction,
+image export, code/formula/picture/chart enrichments, VLM presets and custom
+configuration, layout/table/classification presets, deprecated legacy VLM and
+picture-description options, timeout, and abort behavior.
+
+Options merge shallowly: constructor defaults are copied, per-call values
+replace top-level fields, `undefined` leaves a default unchanged, and `null`
+clears an optional default. An index signature preserves forward compatibility
+with managed-service options added ahead of this package; the selected
+service's OpenAPI document remains authoritative.
+
+## Docling document types
+
+The client deliberately does not pin `@docling/docling-core`. Its default
+`DoclingDocument` is a version-neutral JSON boundary. Applications wanting the
+exact schema from their installed core package can parameterize the client:
+
+```ts
+import type { DoclingDocument } from '@docling/docling-core';
+import { DoclingClient } from '@docling/docling-client';
+
+const client = new DoclingClient<DoclingDocument>({ baseUrl, apiKey });
+```
+
+This keeps service-client releases independent from document-schema releases
+while preserving full static typing when desired.
+
+## Custom transports
+
+Hosts such as n8n can inject HTTP:
+
+```ts
+import { DoclingClient, type DoclingTransport } from '@docling/docling-client';
+
+const transport: DoclingTransport = {
+  async request<T>(request) {
+    return platformHttpRequest(request) as Promise<T>;
+  },
+  async close() {
+    await platformHttpClose();
+  },
+};
+
+const client = new DoclingClient({
+  baseUrl: 'https://managed-docling.example.com',
+  transport,
+});
+```
+
+A custom transport is the complete HTTP policy boundary: it must preserve
+binary responses, exact-200 behavior, retry/error mapping, headers, timeout,
+and cancellation described by `DoclingTransportRequest`. It cannot be combined
+with the built-in fetch/retry options. WebSocket watching and artifact
+downloads remain separately injectable.
+
+## Development
+
+```sh
+npm install
+npm run check
+```
+
+The unit suite requires no live service. To verify endpoint, response-content,
+schema-property, required-field, target/connector, and enum compatibility
+against a running service:
+
+```sh
+DOCLING_API_KEY=... \
+  npm run contract:check -- https://managed-docling.example.com/openapi.json
+```
+
+See [Python client parity](./PYTHON_CLIENT_PARITY.md) for the complete
+feature-by-feature comparison.

--- a/docling-client/eslint.config.mjs
+++ b/docling-client/eslint.config.mjs
@@ -1,0 +1,21 @@
+// @ts-check
+
+import eslint from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['dist', 'node_modules'],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.browser,
+      },
+    },
+  }
+);

--- a/docling-client/package-lock.json
+++ b/docling-client/package-lock.json
@@ -1,0 +1,3893 @@
+{
+  "name": "@docling/docling-client",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@docling/docling-client",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2",
+        "ipaddr.js": "^2.2.0",
+        "isomorphic-ws": "^5.0.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "9.39.5",
+        "@types/node": "^24.1.0",
+        "@types/ws": "^8.18.1",
+        "eslint": "10.8.0",
+        "globals": "15.14.0",
+        "prettier": "3.8.3",
+        "tsup": "8.5.1",
+        "typescript": "5.9.3",
+        "typescript-eslint": "8.65.0",
+        "vitest": "4.1.10"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+      "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^2.0.0-alpha.3",
+        "@emnapi/runtime": "^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/docling-client/package.json
+++ b/docling-client/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@docling/docling-client",
+  "version": "0.1.0",
+  "description": "TypeScript client for Docling Serve and Docling for IBM watsonx.",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "PYTHON_CLIENT_PARITY.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "contract:check": "node scripts/check-openapi.mjs",
+    "dev": "tsup --watch",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run format:check && npm run lint && npm run typecheck && npm test && npm run build"
+  },
+  "keywords": [
+    "docling",
+    "document-conversion",
+    "typescript",
+    "client",
+    "sdk"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/docling-project/docling-ts.git",
+    "directory": "docling-client"
+  },
+  "bugs": {
+    "url": "https://github.com/docling-project/docling-ts/issues"
+  },
+  "homepage": "https://github.com/docling-project/docling-ts/tree/main/docling-client",
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "dependencies": {
+    "fflate": "^0.8.2",
+    "ipaddr.js": "^2.2.0",
+    "isomorphic-ws": "^5.0.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "9.39.5",
+    "@types/node": "^24.1.0",
+    "@types/ws": "^8.18.1",
+    "eslint": "10.8.0",
+    "globals": "15.14.0",
+    "prettier": "3.8.3",
+    "tsup": "8.5.1",
+    "typescript": "5.9.3",
+    "typescript-eslint": "8.65.0",
+    "vitest": "4.1.10"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "overrides": {
+    "esbuild": "0.28.1"
+  }
+}

--- a/docling-client/scripts/check-openapi.mjs
+++ b/docling-client/scripts/check-openapi.mjs
@@ -1,0 +1,581 @@
+const openApiUrl =
+  process.argv[2] ??
+  process.env.DOCLING_OPENAPI_URL ??
+  'http://localhost:5001/openapi.json';
+
+const response = await fetch(openApiUrl, {
+  headers:
+    process.env.DOCLING_API_KEY === undefined
+      ? {}
+      : { 'X-Api-Key': process.env.DOCLING_API_KEY },
+});
+
+if (!response.ok) {
+  throw new Error(
+    `Could not fetch ${openApiUrl}: HTTP ${response.status} ${response.statusText}`
+  );
+}
+
+const specification = await response.json();
+assertObject(specification, 'OpenAPI document');
+assertPath(specification, '/v1/convert/source/async', 'post');
+assertPath(specification, '/v1/convert/file/async', 'post');
+assertPath(specification, '/v1/convert/source/batch', 'post');
+assertPath(specification, '/v1/chunk/hybrid/source/async', 'post');
+assertPath(specification, '/v1/chunk/hybrid/file/async', 'post');
+assertPath(specification, '/v1/chunk/hierarchical/source/async', 'post');
+assertPath(specification, '/v1/chunk/hierarchical/file/async', 'post');
+assertPath(specification, '/v1/status/poll/{task_id}', 'get');
+assertPath(specification, '/v1/result/{task_id}', 'get');
+assertPath(specification, '/health', 'get');
+assertPath(specification, '/version', 'get');
+assertJsonRequest(specification, '/v1/convert/source/async', 'post');
+assertJsonRequest(specification, '/v1/convert/source/batch', 'post');
+assertMultipartRequest(specification, '/v1/convert/file/async', 'post');
+assertJsonRequest(specification, '/v1/chunk/hybrid/source/async', 'post');
+assertMultipartRequest(specification, '/v1/chunk/hybrid/file/async', 'post');
+assertJsonRequest(specification, '/v1/chunk/hierarchical/source/async', 'post');
+assertMultipartRequest(specification, '/v1/chunk/hierarchical/file/async', 'post');
+assertPathParameter(specification, '/v1/status/poll/{task_id}', 'get', 'task_id');
+assertPathParameter(specification, '/v1/result/{task_id}', 'get', 'task_id');
+assertRequestProperties(
+  specification,
+  '/v1/convert/source/async',
+  'post',
+  'application/json',
+  ['sources', 'target', 'options', 'callbacks']
+);
+assertRequestProperties(
+  specification,
+  '/v1/convert/source/batch',
+  'post',
+  'application/json',
+  ['sources', 'target', 'options', 'callbacks']
+);
+assertRequestProperties(
+  specification,
+  '/v1/convert/file/async',
+  'post',
+  'multipart/form-data',
+  ['files', 'target_type', 'from_formats', 'to_formats', 'pipeline', 'page_range']
+);
+for (const path of [
+  '/v1/chunk/hybrid/source/async',
+  '/v1/chunk/hierarchical/source/async',
+]) {
+  assertRequestProperties(specification, path, 'post', 'application/json', [
+    'convert_options',
+    'chunking_options',
+    'sources',
+    'include_converted_doc',
+    'target',
+    'callbacks',
+  ]);
+}
+for (const path of [
+  '/v1/chunk/hybrid/file/async',
+  '/v1/chunk/hierarchical/file/async',
+]) {
+  assertRequestProperties(specification, path, 'post', 'multipart/form-data', [
+    'files',
+    'convert_from_formats',
+    'convert_pipeline',
+    'chunking_use_markdown_tables',
+    'chunking_use_markdown_images',
+    'chunking_image_placeholder',
+    'chunking_include_raw_text',
+    'include_converted_doc',
+    'target_type',
+  ]);
+}
+assertRequestProperties(
+  specification,
+  '/v1/chunk/hybrid/file/async',
+  'post',
+  'multipart/form-data',
+  ['chunking_max_tokens', 'chunking_tokenizer', 'chunking_merge_peers']
+);
+assertResponseContent(
+  specification,
+  '/v1/result/{task_id}',
+  'get',
+  '200',
+  'application/zip'
+);
+assertResponseContent(
+  specification,
+  '/v1/result/{task_id}',
+  'get',
+  '200',
+  'application/json'
+);
+
+const schemas = specification.components?.schemas;
+assertObject(schemas, 'OpenAPI components.schemas');
+
+const convertOptions = getSchema(schemas, ['ConvertDocumentsOptions']);
+assertProperties(convertOptions, [
+  'from_formats',
+  'to_formats',
+  'image_export_mode',
+  'do_ocr',
+  'force_ocr',
+  'ocr_engine',
+  'ocr_lang',
+  'ocr_preset',
+  'ocr_custom_config',
+  'pdf_backend',
+  'table_mode',
+  'table_cell_matching',
+  'pipeline',
+  'page_range',
+  'document_timeout',
+  'abort_on_error',
+  'do_table_structure',
+  'include_images',
+  'include_page_images',
+  'images_scale',
+  'md_page_break_placeholder',
+  'do_code_enrichment',
+  'do_formula_enrichment',
+  'do_picture_classification',
+  'do_chart_extraction',
+  'do_picture_description',
+  'picture_description_area_threshold',
+  'picture_description_local',
+  'picture_description_api',
+  'vlm_pipeline_model',
+  'vlm_pipeline_model_local',
+  'vlm_pipeline_model_api',
+  'vlm_pipeline_preset',
+  'picture_description_preset',
+  'code_formula_preset',
+  'vlm_pipeline_custom_config',
+  'picture_description_custom_config',
+  'code_formula_custom_config',
+  'table_structure_preset',
+  'table_structure_custom_config',
+  'layout_custom_config',
+  'layout_preset',
+  'picture_classification_preset',
+  'picture_classification_custom_config',
+]);
+
+const convertRequest = getSchema(schemas, [
+  'ConvertSourcesRequest',
+  'ConvertDocumentsRequest',
+]);
+assertProperties(convertRequest, ['sources', 'target', 'options', 'callbacks']);
+assertRequired(convertRequest, ['sources']);
+
+const batchRequest = getSchema(schemas, ['BatchConvertSourcesRequest']);
+assertProperties(batchRequest, ['sources', 'target', 'options', 'callbacks']);
+assertRequired(batchRequest, ['sources', 'target']);
+
+const taskStatus = getSchema(schemas, ['TaskStatusResponse']);
+assertProperties(taskStatus, [
+  'task_id',
+  'task_type',
+  'task_status',
+  'task_position',
+  'task_meta',
+  'error_message',
+  'failure',
+]);
+assertRequired(taskStatus, ['task_id', 'task_type', 'task_status']);
+
+const convertResponse = getSchema(schemas, ['ConvertDocumentResponse']);
+assertProperties(convertResponse, [
+  'document',
+  'status',
+  'errors',
+  'processing_time',
+  'timings',
+  'confidence',
+]);
+assertRequired(convertResponse, ['document', 'status', 'processing_time']);
+
+const chunkResponse = getSchema(schemas, ['ChunkDocumentResponse']);
+assertProperties(chunkResponse, ['chunks', 'documents', 'processing_time']);
+assertRequired(chunkResponse, ['chunks', 'documents', 'processing_time']);
+
+const countsResponse = getSchema(schemas, ['PresignedUrlConvertDocumentResponse']);
+assertProperties(countsResponse, [
+  'num_converted',
+  'num_succeeded',
+  'num_partially_succeeded',
+  'num_failed',
+  'processing_time',
+]);
+assertRequired(countsResponse, [
+  'num_converted',
+  'num_succeeded',
+  'num_failed',
+  'processing_time',
+]);
+
+const presignedResponse = getSchema(schemas, ['PresignedUrlConvertResponse']);
+assertProperties(presignedResponse, ['documents']);
+assertRequired(presignedResponse, ['documents']);
+
+const artifactItem = getSchema(schemas, ['DocumentArtifactItem']);
+assertProperties(artifactItem, [
+  'source_index',
+  'source_uri',
+  'filename',
+  'status',
+  'errors',
+  'timings',
+  'artifacts',
+  'confidence',
+]);
+assertRequired(artifactItem, ['source_index', 'source_uri', 'filename', 'status']);
+
+const artifactRef = getSchema(schemas, ['ArtifactRef']);
+assertProperties(artifactRef, ['artifact_type', 'mime_type', 'uri', 'url_expires_at']);
+assertRequired(artifactRef, ['artifact_type', 'mime_type', 'uri']);
+
+for (const [targetName, kind] of [
+  ['InBodyTarget', 'inbody'],
+  ['ZipTarget', 'zip'],
+  ['PutTarget', 'put'],
+  ['PresignedUrlTarget', 'presigned_url'],
+  ['S3Target', 's3'],
+  ['AzureBlobTarget', 'azure_blob'],
+  ['GoogleCloudStorageTarget', 'google_cloud_storage'],
+  ['GoogleDriveTarget', 'google_drive'],
+]) {
+  const target = getSchema(schemas, [targetName]);
+  assertProperties(target, ['kind']);
+  assertPropertyLiteral(target, 'kind', kind);
+}
+
+const fileSource = getSchema(schemas, ['FileSourceRequest']);
+assertProperties(fileSource, ['kind', 'base64_string', 'filename']);
+assertRequired(fileSource, ['base64_string', 'filename']);
+assertPropertyLiteral(fileSource, 'kind', 'file');
+
+const httpSource = getSchema(schemas, ['AnyHttpSourceRequest', 'HttpSourceRequest']);
+assertProperties(httpSource, ['kind', 'url', 'headers']);
+assertRequired(httpSource, ['url']);
+assertPropertyLiteral(httpSource, 'kind', 'http');
+
+assertConnector(
+  schemas,
+  ['S3SourceRequest'],
+  's3',
+  ['endpoint', 'verify_ssl', 'access_key', 'secret_key', 'bucket', 'key_prefix'],
+  ['endpoint', 'access_key', 'secret_key', 'bucket']
+);
+assertConnector(
+  schemas,
+  ['S3Target'],
+  's3',
+  ['endpoint', 'verify_ssl', 'access_key', 'secret_key', 'bucket', 'key_prefix'],
+  ['endpoint', 'access_key', 'secret_key', 'bucket']
+);
+assertConnector(
+  schemas,
+  ['AzureBlobSourceRequest'],
+  'azure_blob',
+  ['account_name', 'container', 'connection_string', 'blob_prefix'],
+  ['account_name', 'container', 'connection_string']
+);
+assertConnector(
+  schemas,
+  ['AzureBlobTarget'],
+  'azure_blob',
+  ['account_name', 'container', 'connection_string', 'blob_prefix'],
+  ['account_name', 'container', 'connection_string']
+);
+assertConnector(
+  schemas,
+  ['GoogleCloudStorageSourceRequest'],
+  'google_cloud_storage',
+  ['bucket', 'key_prefix', 'project', 'service_account_key'],
+  ['bucket']
+);
+assertConnector(
+  schemas,
+  ['GoogleCloudStorageTarget'],
+  'google_cloud_storage',
+  ['bucket', 'key_prefix', 'project', 'service_account_key'],
+  ['bucket']
+);
+assertConnector(
+  schemas,
+  ['GoogleDriveSourceRequest'],
+  'google_drive',
+  ['path_id', 'token_path', 'refresh_token', 'credentials_path', 'credentials'],
+  ['path_id']
+);
+assertConnector(
+  schemas,
+  ['GoogleDriveTarget'],
+  'google_drive',
+  ['path_id', 'token_path', 'refresh_token', 'credentials_path', 'credentials'],
+  ['path_id']
+);
+
+const putTarget = getSchema(schemas, ['PutTarget']);
+assertProperties(putTarget, ['kind', 'url']);
+assertRequired(putTarget, ['url']);
+
+const callback = getSchema(schemas, ['CallbackSpec']);
+assertProperties(callback, ['url', 'headers', 'ca_cert']);
+assertRequired(callback, ['url']);
+
+for (const [schemaNames, chunker] of [
+  [['HybridChunkerOptionsDocumentsRequest', 'HybridChunkDocumentsRequest'], 'hybrid'],
+  [
+    ['HierarchicalChunkerOptionsDocumentsRequest', 'HierarchicalChunkDocumentsRequest'],
+    'hierarchical',
+  ],
+]) {
+  const request = getSchema(schemas, schemaNames);
+  assertProperties(request, [
+    'convert_options',
+    'sources',
+    'include_converted_doc',
+    'target',
+    'callbacks',
+    'chunking_options',
+  ]);
+  assertChunkerLiteral(specification, request, chunker);
+}
+
+assertEnumContains(
+  schemas,
+  ['InputFormat'],
+  [
+    'docx',
+    'doc',
+    'pptx',
+    'html',
+    'image',
+    'pdf',
+    'asciidoc',
+    'md',
+    'csv',
+    'xlsx',
+    'xml_uspto',
+    'xml_jats',
+    'json_docling',
+    'dclx',
+    'audio',
+    'vtt',
+    'xml_xbrl',
+    'mets_gbs',
+    'latex',
+    'ppt',
+    'xls',
+    'odt',
+    'ods',
+    'odp',
+    'xml_doclang',
+    'video',
+    'email',
+    'epub',
+    'boxnote',
+  ]
+);
+assertEnumContains(
+  schemas,
+  ['OutputFormat'],
+  [
+    'md',
+    'json',
+    'yaml',
+    'html',
+    'html_split_page',
+    'text',
+    'doctags',
+    'vtt',
+    'doclang',
+    'dclx',
+    'chunks',
+  ]
+);
+assertEnumContains(
+  schemas,
+  ['ConversionStatus'],
+  ['pending', 'started', 'success', 'failure', 'partial_success', 'skipped']
+);
+
+process.stdout.write(
+  `Docling client contract checks passed for ${openApiUrl} (${specification.info?.version ?? 'unknown version'}).\n`
+);
+
+function assertPath(spec, path, method) {
+  if (spec.paths?.[path]?.[method] === undefined) {
+    throw new Error(`OpenAPI is missing ${method.toUpperCase()} ${path}`);
+  }
+}
+
+function operation(spec, path, method) {
+  const value = spec.paths?.[path]?.[method];
+  assertObject(value, `${method.toUpperCase()} ${path}`);
+  return value;
+}
+
+function assertJsonRequest(spec, path, method) {
+  const requestBody = operation(spec, path, method).requestBody;
+  assertObject(requestBody, `${method.toUpperCase()} ${path} request body`);
+  if (requestBody.content?.['application/json'] === undefined) {
+    throw new Error(
+      `OpenAPI is missing application/json for ${method.toUpperCase()} ${path} request`
+    );
+  }
+}
+
+function assertMultipartRequest(spec, path, method) {
+  const requestBody = operation(spec, path, method).requestBody;
+  assertObject(requestBody, `${method.toUpperCase()} ${path} request body`);
+  if (requestBody.content?.['multipart/form-data'] === undefined) {
+    throw new Error(
+      `OpenAPI is missing multipart/form-data for ${method.toUpperCase()} ${path} request`
+    );
+  }
+}
+
+function assertRequestProperties(spec, path, method, contentType, names) {
+  const requestSchema = operation(spec, path, method).requestBody?.content?.[
+    contentType
+  ]?.schema;
+  assertObject(
+    requestSchema,
+    `${method.toUpperCase()} ${path} ${contentType} request schema`
+  );
+  const resolved = flattenSchema(spec, requestSchema);
+  assertProperties(resolved, names);
+}
+
+function assertPathParameter(spec, path, method, parameterName) {
+  const parameters = operation(spec, path, method).parameters ?? [];
+  if (
+    !parameters.some(
+      parameter =>
+        parameter?.name === parameterName &&
+        parameter?.in === 'path' &&
+        parameter?.required === true
+    )
+  ) {
+    throw new Error(
+      `OpenAPI is missing required path parameter ${parameterName} for ${method.toUpperCase()} ${path}`
+    );
+  }
+}
+
+function getSchema(schemas, acceptedNames) {
+  const name = acceptedNames.find(candidate => schemas[candidate] !== undefined);
+  if (name === undefined) {
+    throw new Error(
+      `OpenAPI is missing a compatible schema: ${acceptedNames.join(' or ')}`
+    );
+  }
+  const schema = schemas[name];
+  assertObject(schema, `OpenAPI schema ${name}`);
+  return schema;
+}
+
+function assertConnector(schemas, schemaNames, kind, properties, required) {
+  const schema = getSchema(schemas, schemaNames);
+  assertProperties(schema, ['kind', ...properties]);
+  assertRequired(schema, required);
+  assertPropertyLiteral(schema, 'kind', kind);
+}
+
+function assertPropertyLiteral(schema, propertyName, expected) {
+  const property = schema.properties?.[propertyName];
+  assertObject(property, `OpenAPI property ${propertyName}`);
+  const values =
+    property.enum ?? (property.const === undefined ? [] : [property.const]);
+  if (!values.includes(expected) && property.default !== expected) {
+    throw new Error(
+      `OpenAPI property ${propertyName} does not declare literal ${expected}`
+    );
+  }
+}
+
+function assertChunkerLiteral(spec, requestSchema, expected) {
+  const chunkingProperty = requestSchema.properties?.chunking_options;
+  assertObject(chunkingProperty, 'OpenAPI chunking_options property');
+  const chunkingSchema = dereference(spec, chunkingProperty);
+  assertPropertyLiteral(chunkingSchema, 'chunker', expected);
+}
+
+function dereference(spec, schema) {
+  if (typeof schema.$ref !== 'string') {
+    return schema;
+  }
+  const prefix = '#/components/schemas/';
+  if (!schema.$ref.startsWith(prefix)) {
+    throw new Error(`Unsupported OpenAPI schema reference ${schema.$ref}`);
+  }
+  const resolved = spec.components?.schemas?.[schema.$ref.slice(prefix.length)];
+  assertObject(resolved, `OpenAPI schema ${schema.$ref}`);
+  return resolved;
+}
+
+function flattenSchema(spec, schema) {
+  const resolved = dereference(spec, schema);
+  const composed = [...(resolved.allOf ?? []), ...(resolved.anyOf ?? [])];
+  if (composed.length === 0) {
+    return resolved;
+  }
+  const properties = { ...(resolved.properties ?? {}) };
+  const required = new Set(resolved.required ?? []);
+  for (const member of composed) {
+    const flattened = flattenSchema(spec, member);
+    Object.assign(properties, flattened.properties ?? {});
+    for (const name of flattened.required ?? []) {
+      required.add(name);
+    }
+  }
+  return { ...resolved, properties, required: [...required] };
+}
+
+function assertProperties(schema, names) {
+  assertObject(schema.properties, 'OpenAPI schema properties');
+  for (const name of names) {
+    if (schema.properties[name] === undefined) {
+      throw new Error(`OpenAPI schema is missing property ${name}`);
+    }
+  }
+}
+
+function assertRequired(schema, names) {
+  const required = new Set(schema.required ?? []);
+  for (const name of names) {
+    if (!required.has(name)) {
+      throw new Error(`OpenAPI schema does not require ${name}`);
+    }
+  }
+}
+
+function assertEnumContains(schemas, acceptedNames, values) {
+  const schema = getSchema(schemas, acceptedNames);
+  const actual = new Set(schema.enum ?? []);
+  for (const value of values) {
+    if (!actual.has(value)) {
+      throw new Error(`OpenAPI enum ${acceptedNames.join('/')} is missing ${value}`);
+    }
+  }
+}
+
+function assertResponseContent(spec, path, method, status, contentType) {
+  if (
+    spec.paths?.[path]?.[method]?.responses?.[status]?.content?.[contentType] ===
+    undefined
+  ) {
+    throw new Error(
+      `OpenAPI is missing ${contentType} for ${method.toUpperCase()} ${path} response ${status}`
+    );
+  }
+}
+
+function assertObject(value, name) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${name} must be an object`);
+  }
+}

--- a/docling-client/src/artifacts.ts
+++ b/docling-client/src/artifacts.ts
@@ -1,0 +1,613 @@
+import { Unzip, UnzipInflate } from 'fflate';
+import ipaddr from 'ipaddr.js';
+
+import { DoclingArtifactDownloadError } from './errors';
+import type {
+  ArtifactRef,
+  ConversionInput,
+  ConversionResult,
+  DoclingDocument,
+  DocumentArtifactItem,
+  ErrorItem,
+  PresignedUrlConvertResponse,
+} from './types';
+
+export type ArtifactAddressResolver = (hostname: string) => Promise<string[]>;
+
+export interface ArtifactDownloaderOptions {
+  fetch?: typeof globalThis.fetch;
+  resolver?: ArtifactAddressResolver;
+  allowPrivateUrls?: boolean;
+  timeoutMs?: number;
+  maxBytes?: number;
+  maxRedirects?: number;
+}
+
+export class ArtifactDownloader {
+  readonly #fetch: typeof globalThis.fetch;
+  readonly #resolver: ArtifactAddressResolver;
+  readonly #allowPrivateUrls: boolean;
+  readonly #timeoutMs: number;
+  readonly #maxBytes: number;
+  readonly #maxRedirects: number;
+
+  constructor(options: ArtifactDownloaderOptions = {}) {
+    if (options.fetch === undefined && globalThis.fetch === undefined) {
+      throw new DoclingArtifactDownloadError(
+        'No fetch implementation is available for artifact downloads'
+      );
+    }
+    this.#fetch = options.fetch ?? globalThis.fetch;
+    this.#resolver = options.resolver ?? resolveAllAddresses;
+    this.#allowPrivateUrls = options.allowPrivateUrls ?? false;
+    this.#timeoutMs = options.timeoutMs ?? 60_000;
+    this.#maxBytes = options.maxBytes ?? 512 * 1024 * 1024;
+    this.#maxRedirects = options.maxRedirects ?? 5;
+    validateArtifactLimits(this.#timeoutMs, this.#maxBytes, this.#maxRedirects);
+  }
+
+  async download(url: string, signal?: AbortSignal): Promise<Uint8Array> {
+    let currentUrl = url;
+    for (let redirects = 0; redirects <= this.#maxRedirects; redirects += 1) {
+      await this.#validateUrl(currentUrl);
+      const controller = new AbortController();
+      const timeout = setTimeout(() => {
+        controller.abort(
+          new DoclingArtifactDownloadError(
+            `Artifact download exceeded ${this.#timeoutMs} ms`
+          )
+        );
+      }, this.#timeoutMs);
+      const combinedSignal = combineAbortSignals(signal, controller.signal);
+
+      try {
+        const response = await this.#fetch(currentUrl, {
+          redirect: 'manual',
+          signal: combinedSignal,
+        });
+        if (isRedirect(response.status)) {
+          if (redirects >= this.#maxRedirects) {
+            throw new DoclingArtifactDownloadError(
+              `Artifact download exceeded ${this.#maxRedirects} redirects`
+            );
+          }
+          const location = response.headers.get('location');
+          if (location === null || location === '') {
+            throw new DoclingArtifactDownloadError(
+              'Artifact redirect response is missing Location'
+            );
+          }
+          currentUrl = new URL(location, currentUrl).toString();
+          await response.body?.cancel();
+          continue;
+        }
+        if (response.status !== 200) {
+          throw new DoclingArtifactDownloadError(
+            `Artifact download returned HTTP ${response.status}`
+          );
+        }
+        return await readBoundedBody(response, this.#maxBytes, combinedSignal);
+      } catch (error) {
+        if (signal?.aborted === true) {
+          throw signal.reason;
+        }
+        if (error instanceof DoclingArtifactDownloadError) {
+          throw error;
+        }
+        throw new DoclingArtifactDownloadError(
+          `Artifact download failed for ${currentUrl}`,
+          { cause: error }
+        );
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+
+    throw new DoclingArtifactDownloadError('Artifact redirect loop did not terminate');
+  }
+
+  async #validateUrl(value: string): Promise<void> {
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch (error) {
+      throw new DoclingArtifactDownloadError('Artifact URL is invalid', {
+        cause: error,
+      });
+    }
+    if (!['http:', 'https:'].includes(url.protocol) || url.hostname === '') {
+      throw new DoclingArtifactDownloadError(
+        'Artifact URL must be an absolute HTTP(S) URL'
+      );
+    }
+    if (this.#allowPrivateUrls) {
+      return;
+    }
+
+    const hostname = url.hostname.replace(/^\[|\]$/g, '');
+    let addresses: string[];
+    try {
+      addresses = ipaddr.isValid(hostname)
+        ? [hostname]
+        : await this.#resolver(hostname);
+    } catch (error) {
+      throw new DoclingArtifactDownloadError(
+        `Could not resolve artifact host ${hostname}`,
+        { cause: error }
+      );
+    }
+    if (
+      addresses.length === 0 ||
+      addresses.some(address => !isGlobalAddress(address))
+    ) {
+      throw new DoclingArtifactDownloadError(
+        `Artifact URL does not resolve exclusively to globally routable addresses: ${url.hostname}`
+      );
+    }
+  }
+}
+
+export async function materializePresignedResult<TDocument = DoclingDocument>(
+  response: PresignedUrlConvertResponse,
+  input: ConversionInput,
+  downloader: ArtifactDownloader,
+  signal?: AbortSignal
+): Promise<ConversionResult<TDocument>> {
+  const item = response.documents[0];
+  if (item === undefined) {
+    return failedConversion(
+      input,
+      response.processing_time,
+      'Presigned result contained no documents'
+    );
+  }
+  if (item.status === 'failure') {
+    return conversionFromArtifactItem<TDocument>(
+      item,
+      input,
+      response.processing_time,
+      emptyDocument<TDocument>(item.filename || input.filename)
+    );
+  }
+
+  try {
+    const artifact = selectDocumentArtifact(item);
+    const bytes = await downloader.download(artifact.uri, signal);
+    const document =
+      artifact.artifact_type === 'resource_bundle'
+        ? documentFromBundle<TDocument>(bytes)
+        : documentFromJson<TDocument>(bytes);
+    return conversionFromArtifactItem(item, input, response.processing_time, document);
+  } catch (error) {
+    if (signal?.aborted === true || isAbortError(error)) {
+      throw signal?.reason ?? error;
+    }
+    const message =
+      error instanceof DoclingArtifactDownloadError
+        ? error.message
+        : `Failed to reconstruct document from presigned artifacts: ${
+            error instanceof Error ? error.message : String(error)
+          }`;
+    return failedConversion(input, response.processing_time, message);
+  }
+}
+
+function isAbortError(value: unknown): boolean {
+  return value instanceof Error && value.name === 'AbortError';
+}
+
+export function selectDocumentArtifact(item: DocumentArtifactItem): ArtifactRef {
+  const bundle = item.artifacts.find(
+    artifact => artifact.artifact_type === 'resource_bundle'
+  );
+  if (bundle !== undefined) {
+    return bundle;
+  }
+  const json = item.artifacts.find(artifact => artifact.artifact_type === 'json');
+  if (json !== undefined) {
+    return json;
+  }
+  throw new DoclingArtifactDownloadError(
+    "Presigned result exposes neither a 'json' nor a 'resource_bundle' artifact"
+  );
+}
+
+export function documentFromBundle<TDocument>(bytes: Uint8Array): TDocument {
+  let entries: Record<string, Uint8Array>;
+  try {
+    entries = unzipBundle(bytes);
+  } catch (error) {
+    if (error instanceof DoclingArtifactDownloadError) {
+      throw error;
+    }
+    throw new DoclingArtifactDownloadError(
+      'Downloaded resource bundle is not a valid ZIP',
+      { cause: error }
+    );
+  }
+  for (const name of Object.keys(entries)) {
+    validateBundlePath(name);
+  }
+  const jsonNames = Object.keys(entries)
+    .filter(name => !name.includes('/') && name.toLowerCase().endsWith('.json'))
+    .sort();
+  if (jsonNames.length !== 1) {
+    throw new DoclingArtifactDownloadError(
+      `Resource bundle must contain exactly one top-level JSON document; found ${jsonNames.length}`
+    );
+  }
+  const jsonName = jsonNames[0] as string;
+  const jsonBytes = entries[jsonName];
+  if (jsonBytes === undefined) {
+    throw new DoclingArtifactDownloadError('Resource bundle JSON is missing');
+  }
+  const document = documentFromJson<TDocument>(jsonBytes);
+  embedBundleImages(document, entries);
+  return document;
+}
+
+export function documentFromJson<TDocument>(bytes: Uint8Array): TDocument {
+  let value: unknown;
+  try {
+    value = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+  } catch (error) {
+    throw new DoclingArtifactDownloadError(
+      'Downloaded artifact is not valid Docling JSON',
+      { cause: error }
+    );
+  }
+  if (
+    !isRecord(value) ||
+    value.schema_name !== 'DoclingDocument' ||
+    typeof value.name !== 'string'
+  ) {
+    throw new DoclingArtifactDownloadError(
+      'Downloaded artifact is not a DoclingDocument'
+    );
+  }
+  return value as TDocument;
+}
+
+function conversionFromArtifactItem<TDocument>(
+  item: DocumentArtifactItem,
+  fallbackInput: ConversionInput,
+  processingTime: number,
+  document: TDocument
+): ConversionResult<TDocument> {
+  return {
+    input: {
+      ...fallbackInput,
+      filename: item.filename || fallbackInput.filename,
+      source: item.source_uri || fallbackInput.source,
+    },
+    document,
+    status: item.status,
+    errors: item.errors,
+    processing_time: processingTime,
+    timings: item.timings,
+    ...(item.confidence === undefined ? {} : { confidence: item.confidence }),
+  };
+}
+
+function failedConversion<TDocument>(
+  input: ConversionInput,
+  processingTime: number,
+  message: string
+): ConversionResult<TDocument> {
+  const error: ErrorItem = {
+    component_type: 'user_input',
+    module_name: '@docling/docling-client',
+    error_message: message,
+    category: 'unknown',
+  };
+  return {
+    input,
+    document: emptyDocument<TDocument>(input.filename),
+    status: 'failure',
+    errors: [error],
+    processing_time: processingTime,
+    timings: {},
+  };
+}
+
+function emptyDocument<TDocument>(filename: string): TDocument {
+  const leaf = filename.replaceAll('\\', '/').split('/').at(-1) ?? filename;
+  const extension = leaf.lastIndexOf('.');
+  const name = extension > 0 ? leaf.slice(0, extension) : leaf;
+  return {
+    schema_name: 'DoclingDocument',
+    name: name || 'document',
+  } as TDocument;
+}
+
+function embedBundleImages(
+  document: unknown,
+  entries: Readonly<Record<string, Uint8Array>>
+): void {
+  if (!isRecord(document)) {
+    return;
+  }
+  if (Array.isArray(document.pictures)) {
+    for (const picture of document.pictures) {
+      if (isRecord(picture) && isRecord(picture.image)) {
+        embedImageRef(picture.image, entries);
+      }
+    }
+  }
+  if (isRecord(document.pages)) {
+    for (const page of Object.values(document.pages)) {
+      if (isRecord(page) && isRecord(page.image)) {
+        embedImageRef(page.image, entries);
+      }
+    }
+  }
+}
+
+function embedImageRef(
+  value: Record<string, unknown>,
+  entries: Readonly<Record<string, Uint8Array>>
+): void {
+  if (!isImageRef(value)) {
+    throw new DoclingArtifactDownloadError(
+      'Resource bundle contains an invalid image reference'
+    );
+  }
+  const uri = value.uri;
+  if (
+    uri.startsWith('data:') ||
+    uri.startsWith('http://') ||
+    uri.startsWith('https://')
+  ) {
+    return;
+  }
+  const path = normalizeBundleReference(uri);
+  const content = entries[path];
+  if (content === undefined) {
+    throw new DoclingArtifactDownloadError(`Resource bundle image is missing: ${uri}`);
+  }
+  if (!isSupportedImage(value.mimetype, content)) {
+    throw new DoclingArtifactDownloadError(
+      `Resource bundle image bytes do not match ${value.mimetype}`
+    );
+  }
+  value.uri = `data:${value.mimetype};base64,${bytesToBase64(content)}`;
+}
+
+function validateBundlePath(value: string): void {
+  const normalized = value.replaceAll('\\', '/');
+  if (
+    normalized.startsWith('/') ||
+    /^[a-z]:\//i.test(normalized) ||
+    normalized.split('/').some(part => part === '..')
+  ) {
+    throw new DoclingArtifactDownloadError(
+      `Resource bundle contains an unsafe path: ${value}`
+    );
+  }
+}
+
+function normalizeBundleReference(value: string): string {
+  validateBundlePath(value);
+  return value.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function isImageRef(value: Record<string, unknown>): value is Record<
+  string,
+  unknown
+> & {
+  mimetype: string;
+  dpi: number;
+  uri: string;
+} {
+  return (
+    typeof value.mimetype === 'string' &&
+    typeof value.dpi === 'number' &&
+    typeof value.uri === 'string'
+  );
+}
+
+function isSupportedImage(mimeType: string, bytes: Uint8Array): boolean {
+  const mime = mimeType.toLowerCase();
+  if (mime === 'image/png') {
+    return startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  }
+  if (mime === 'image/jpeg') {
+    return startsWith(bytes, [0xff, 0xd8, 0xff]);
+  }
+  if (mime === 'image/gif') {
+    return new TextDecoder().decode(bytes.subarray(0, 6)).startsWith('GIF8');
+  }
+  if (mime === 'image/webp') {
+    return (
+      new TextDecoder().decode(bytes.subarray(0, 4)) === 'RIFF' &&
+      new TextDecoder().decode(bytes.subarray(8, 12)) === 'WEBP'
+    );
+  }
+  if (mime === 'image/bmp') {
+    return startsWith(bytes, [0x42, 0x4d]);
+  }
+  if (mime === 'image/tiff') {
+    return (
+      startsWith(bytes, [0x49, 0x49, 0x2a, 0x00]) ||
+      startsWith(bytes, [0x4d, 0x4d, 0x00, 0x2a])
+    );
+  }
+  return false;
+}
+
+function startsWith(bytes: Uint8Array, prefix: number[]): boolean {
+  return (
+    bytes.length >= prefix.length &&
+    prefix.every((value, index) => bytes[index] === value)
+  );
+}
+
+function unzipBundle(bytes: Uint8Array): Record<string, Uint8Array> {
+  const entries: Record<string, Uint8Array> = {};
+  const maxEntries = 10_000;
+  const maxUncompressedBytes = 512 * 1024 * 1024;
+  let entryCount = 0;
+  let total = 0;
+  const archive = new Unzip(file => {
+    entryCount += 1;
+    if (entryCount > maxEntries) {
+      throw new DoclingArtifactDownloadError(
+        `Resource bundle exceeds ${maxEntries} entries`
+      );
+    }
+    validateBundlePath(file.name);
+    const chunks: Uint8Array[] = [];
+    file.ondata = (error, chunk, final) => {
+      if (error !== null) {
+        throw error;
+      }
+      total += chunk.byteLength;
+      if (total > maxUncompressedBytes) {
+        throw new DoclingArtifactDownloadError(
+          `Resource bundle exceeds ${maxUncompressedBytes} uncompressed bytes`
+        );
+      }
+      chunks.push(chunk);
+      if (final) {
+        const content = new Uint8Array(
+          chunks.reduce((sum, value) => sum + value.byteLength, 0)
+        );
+        let offset = 0;
+        for (const value of chunks) {
+          content.set(value, offset);
+          offset += value.byteLength;
+        }
+        entries[file.name] = content;
+      }
+    };
+    file.start();
+  });
+  archive.register(UnzipInflate);
+  archive.push(bytes, true);
+  return entries;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isRedirect(status: number): boolean {
+  return [301, 302, 303, 307, 308].includes(status);
+}
+
+async function readBoundedBody(
+  response: Response,
+  maxBytes: number,
+  signal?: AbortSignal
+): Promise<Uint8Array> {
+  if (response.body === null) {
+    return new Uint8Array();
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      if (signal?.aborted === true) {
+        throw signal.reason;
+      }
+      const next = await reader.read();
+      if (next.done) {
+        break;
+      }
+      total += next.value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new DoclingArtifactDownloadError(
+          `Artifact exceeds the ${maxBytes} byte download limit`
+        );
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+async function resolveAllAddresses(hostname: string): Promise<string[]> {
+  const { lookup } = await import('node:dns/promises');
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  return addresses.map(item => item.address);
+}
+
+function isGlobalAddress(value: string): boolean {
+  if (!ipaddr.isValid(value)) {
+    return false;
+  }
+  const address = ipaddr.parse(value);
+  if (address.kind() === 'ipv6') {
+    const ipv6 = address as ipaddr.IPv6;
+    if (ipv6.isIPv4MappedAddress()) {
+      return ipv6.toIPv4Address().range() === 'unicast';
+    }
+  }
+  return address.range() === 'unicast';
+}
+
+function validateArtifactLimits(
+  timeoutMs: number,
+  maxBytes: number,
+  maxRedirects: number
+): void {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new DoclingArtifactDownloadError('Artifact timeout must be positive');
+  }
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new DoclingArtifactDownloadError(
+      'Artifact size limit must be a non-negative safe integer'
+    );
+  }
+  if (!Number.isSafeInteger(maxRedirects) || maxRedirects < 0) {
+    throw new DoclingArtifactDownloadError(
+      'Artifact redirect limit must be a non-negative safe integer'
+    );
+  }
+}
+
+function combineAbortSignals(
+  callerSignal: AbortSignal | undefined,
+  timeoutSignal: AbortSignal
+): AbortSignal {
+  if (callerSignal === undefined) {
+    return timeoutSignal;
+  }
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([callerSignal, timeoutSignal]);
+  }
+  const controller = new AbortController();
+  const abort = (signal: AbortSignal) => controller.abort(signal.reason);
+  if (callerSignal.aborted) {
+    abort(callerSignal);
+  } else {
+    callerSignal.addEventListener('abort', () => abort(callerSignal), {
+      once: true,
+    });
+  }
+  timeoutSignal.addEventListener('abort', () => abort(timeoutSignal), {
+    once: true,
+  });
+  return controller.signal;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+  let binary = '';
+  for (let offset = 0; offset < bytes.length; offset += 32_768) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768));
+  }
+  return btoa(binary);
+}

--- a/docling-client/src/client.ts
+++ b/docling-client/src/client.ts
@@ -1,0 +1,2633 @@
+import {
+  ArtifactDownloader,
+  type ArtifactDownloaderOptions,
+  materializePresignedResult,
+} from './artifacts';
+import {
+  DoclingConversionError,
+  DoclingHttpError,
+  DoclingProtocolError,
+  DoclingResponseSchemaMismatchError,
+  DoclingResultExpiredError,
+  DoclingResultNotReadyError,
+  DoclingServiceError,
+  DoclingTaskError,
+  DoclingTaskNotFoundError,
+  DoclingTimeoutError,
+} from './errors';
+import { boundedOutcomes, validateConcurrency } from './scheduler';
+import {
+  applyPageLimits,
+  formValue,
+  normalizeSourceInput,
+  preflightFileSize,
+  resolveConvertOptions,
+  validateConvertOptions,
+  validateMaxFileSize,
+  withJsonOutput,
+  type NormalizedSource,
+} from './sources';
+import {
+  FetchTransport,
+  type DoclingBinaryResponse,
+  type DoclingRequestBodyType,
+  type DoclingResponseType,
+  type DoclingTransport,
+  type DoclingTransportRequest,
+  type FetchLike,
+} from './transport';
+import type {
+  AutoSubmitResult,
+  BatchConvertSourcesRequest,
+  BatchResultForTarget,
+  BatchTarget,
+  BinaryFileSource,
+  CallbackSpec,
+  ChunkDocumentResponse,
+  ChunkerKind,
+  ChunkSourceOptions,
+  ChunkSourcesRequest,
+  ConfidenceScores,
+  ConversionInput,
+  ConversionItem,
+  ConversionResult,
+  ConversionSource,
+  ConversionSourceInput,
+  ConvertDocumentsOptions,
+  ConvertDocumentResponse,
+  ConvertSourcesRequest,
+  DoclingDocument,
+  ErrorItem,
+  FailureCategory,
+  FileSource,
+  HealthCheckResponse,
+  HttpSource,
+  InBodyConversionResponse,
+  InBodyTarget,
+  PresignedUrlConvertDocumentResponse,
+  PresignedUrlConvertResponse,
+  PresignedUrlTarget,
+  ProfilingItem,
+  PublicFailureInfo,
+  RawServiceResult,
+  SubmitAndRetrieveOptions,
+  SubmitResultForTarget,
+  SubmitTarget,
+  TaskFailureResult,
+  TaskStatusResponse,
+  WaitForTaskOptions,
+} from './types';
+import { watchTask, type StatusWatcherKind, type WebSocketFactory } from './watchers';
+
+const DEFAULT_JOB_TIMEOUT_MS = 300_000;
+export const DEFAULT_MAX_CONCURRENCY = 8;
+export const MAX_CONCURRENCY_LIMIT = 512;
+
+export interface DoclingClientOptions {
+  baseUrl: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  transport?: DoclingTransport;
+  fetch?: FetchLike;
+  httpRetries?: number;
+  httpTimeoutMs?: number;
+  httpBackoffBaseMs?: number;
+  options?: ConvertDocumentsOptions;
+  statusWatcher?: StatusWatcherKind;
+  webSocketFallbackToPoll?: boolean;
+  webSocketFactory?: WebSocketFactory;
+  connectTimeoutMs?: number;
+  pollServerWaitSeconds?: number;
+  pollClientIntervalMs?: number;
+  jobTimeoutMs?: number;
+  maxConcurrency?: number;
+  artifactDownloader?: ArtifactDownloader;
+  artifactDownload?: ArtifactDownloaderOptions;
+}
+
+export interface SubmitCallOptions {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+}
+
+export interface BatchSubmitCallOptions extends SubmitCallOptions {
+  outputFormats?: ConvertDocumentsOptions['to_formats'];
+}
+
+export interface SubmitSourceOptions<
+  TTarget extends SubmitTarget = SubmitTarget,
+> extends SubmitCallOptions {
+  options?: ConvertDocumentsOptions;
+  outputFormats?: ConvertDocumentsOptions['to_formats'];
+  target?: TTarget;
+}
+
+export interface ConvertOptions extends WaitForTaskOptions {
+  options?: ConvertDocumentsOptions;
+  headers?: Record<string, string>;
+  maxNumPages?: number;
+  maxFileSize?: number;
+  pageRange?: [number, number];
+  raisesOnError?: boolean;
+}
+
+export interface ConvertAllOptions extends Omit<ConvertOptions, 'raisesOnError'> {
+  maxConcurrency?: number;
+}
+
+export interface ChunkCallOptions extends WaitForTaskOptions {
+  includeConvertedDoc?: boolean;
+}
+
+type AnySubmitResult<TDocument> =
+  | AutoSubmitResult<TDocument>
+  | RawServiceResult
+  | PresignedUrlConvertDocumentResponse;
+
+export class DoclingClient<TDocument = DoclingDocument> {
+  readonly #baseUrl: string;
+  readonly #apiKey: string;
+  readonly #headers: Readonly<Record<string, string>>;
+  readonly #transport: DoclingTransport;
+  readonly #defaultOptions: ConvertDocumentsOptions;
+  readonly #statusWatcher: StatusWatcherKind;
+  readonly #webSocketFallbackToPoll: boolean;
+  readonly #webSocketFactory: WebSocketFactory | undefined;
+  readonly #connectTimeoutMs: number;
+  readonly #pollServerWaitSeconds: number;
+  readonly #pollClientIntervalMs: number;
+  readonly #jobTimeoutMs: number;
+  readonly #maxConcurrency: number;
+  readonly #artifactDownloader: ArtifactDownloader;
+  #closed = false;
+
+  constructor(options: DoclingClientOptions) {
+    this.#baseUrl = normalizeBaseUrl(options.baseUrl);
+    this.#apiKey = options.apiKey ?? '';
+    this.#headers = {
+      accept: 'application/json',
+      ...normalizeHeaders(options.headers),
+      ...(this.#apiKey === '' ? {} : { 'x-api-key': this.#apiKey }),
+    };
+    if (
+      options.transport !== undefined &&
+      (options.fetch !== undefined ||
+        options.httpRetries !== undefined ||
+        options.httpTimeoutMs !== undefined ||
+        options.httpBackoffBaseMs !== undefined)
+    ) {
+      throw new DoclingProtocolError(
+        'fetch/http retry options cannot be combined with a custom transport'
+      );
+    }
+    this.#transport =
+      options.transport ??
+      new FetchTransport({
+        ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+        ...(options.httpRetries === undefined ? {} : { retries: options.httpRetries }),
+        ...(options.httpTimeoutMs === undefined
+          ? {}
+          : { timeoutMs: options.httpTimeoutMs }),
+        ...(options.httpBackoffBaseMs === undefined
+          ? {}
+          : { backoffBaseMs: options.httpBackoffBaseMs }),
+      });
+    this.#defaultOptions = resolveConvertOptions({}, options.options);
+    this.#statusWatcher = options.statusWatcher ?? 'websocket';
+    this.#webSocketFallbackToPoll = options.webSocketFallbackToPoll ?? true;
+    this.#webSocketFactory = options.webSocketFactory;
+    this.#connectTimeoutMs = positiveNumber(
+      options.connectTimeoutMs ?? 10_000,
+      'connectTimeoutMs'
+    );
+    this.#pollServerWaitSeconds = nonNegativeNumber(
+      options.pollServerWaitSeconds ?? 5,
+      'pollServerWaitSeconds'
+    );
+    this.#pollClientIntervalMs = nonNegativeNumber(
+      options.pollClientIntervalMs ?? this.#pollServerWaitSeconds * 1_000,
+      'pollClientIntervalMs'
+    );
+    this.#jobTimeoutMs = positiveNumber(
+      options.jobTimeoutMs ?? DEFAULT_JOB_TIMEOUT_MS,
+      'jobTimeoutMs'
+    );
+    this.#maxConcurrency = validateConcurrency(
+      options.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY
+    );
+    this.#artifactDownloader =
+      options.artifactDownloader ?? new ArtifactDownloader(options.artifactDownload);
+  }
+
+  async health(options: { signal?: AbortSignal } = {}): Promise<HealthCheckResponse> {
+    const value = await this.#request<unknown>('GET', '/health', {
+      signal: options.signal,
+      retries: 0,
+    });
+    if (!isRecord(value)) {
+      throw new DoclingResponseSchemaMismatchError(
+        'Docling health response must be an object',
+        { status: 200 }
+      );
+    }
+    if (value.status !== undefined && typeof value.status !== 'string') {
+      throw new DoclingResponseSchemaMismatchError(
+        'Docling health response status must be a string',
+        { status: 200 }
+      );
+    }
+    return { status: value.status ?? 'ok' };
+  }
+
+  async version(
+    options: { signal?: AbortSignal } = {}
+  ): Promise<Record<string, unknown>> {
+    const value = await this.#request<unknown>('GET', '/version', {
+      signal: options.signal,
+      retries: 0,
+    });
+    if (!isRecord(value)) {
+      throw new DoclingResponseSchemaMismatchError(
+        'Docling version response must be an object',
+        { status: 200 }
+      );
+    }
+    return value;
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    await this.#transport.close?.();
+  }
+
+  async submit<TTarget extends SubmitTarget>(
+    request: ConvertSourcesRequest<TTarget> & { target: TTarget },
+    options?: SubmitCallOptions
+  ): Promise<DoclingJob<SubmitResultForTarget<TTarget, TDocument>>>;
+  async submit(
+    request: ConvertSourcesRequest,
+    options?: SubmitCallOptions
+  ): Promise<DoclingJob<AutoSubmitResult<TDocument>>>;
+  async submit(
+    request: ConvertSourcesRequest,
+    options: SubmitCallOptions = {}
+  ): Promise<DoclingJob<AnySubmitResult<TDocument>>> {
+    if (!Array.isArray(request.sources) || request.sources.length !== 1) {
+      throw new DoclingProtocolError(
+        'A single Docling submission requires exactly one source'
+      );
+    }
+    const resolvedOptions = resolveConvertOptions(
+      this.#defaultOptions,
+      request.options
+    );
+    if (request.target === undefined) {
+      return this.#submitWithAutoTarget(
+        {
+          ...request,
+          options: resolvedOptions,
+        },
+        options
+      );
+    }
+    return this.#submitRequestForTarget(
+      {
+        ...request,
+        options: targetNeedsJson(request.target)
+          ? withJsonOutput(resolvedOptions)
+          : resolvedOptions,
+        target: request.target,
+      },
+      options
+    );
+  }
+
+  async submitSource<TTarget extends SubmitTarget>(
+    source: ConversionSourceInput,
+    options: SubmitSourceOptions<TTarget> & { target: TTarget }
+  ): Promise<DoclingJob<SubmitResultForTarget<TTarget, TDocument>>>;
+  async submitSource(
+    source: ConversionSourceInput,
+    options?: SubmitSourceOptions
+  ): Promise<DoclingJob<AutoSubmitResult<TDocument>>>;
+  async submitSource(
+    source: ConversionSourceInput,
+    options: SubmitSourceOptions = {}
+  ): Promise<DoclingJob<AnySubmitResult<TDocument>>> {
+    const normalized = await normalizeSourceInput(source, options.signal);
+    let convertOptions = resolveConvertOptions(this.#defaultOptions, options.options);
+    if (options.outputFormats !== undefined) {
+      convertOptions = {
+        ...convertOptions,
+        to_formats: [...options.outputFormats],
+      };
+      validateConvertOptions(convertOptions);
+    }
+    if (options.target === undefined) {
+      return this.#submitNormalizedWithAutoTarget(normalized, convertOptions, options);
+    }
+    return this.#submitNormalizedForTarget(
+      normalized,
+      targetNeedsJson(options.target) ? withJsonOutput(convertOptions) : convertOptions,
+      options.target,
+      options
+    );
+  }
+
+  submitUrl<TTarget extends SubmitTarget>(
+    url: string,
+    options: ConvertDocumentsOptions,
+    requestOptions: SubmitCallOptions & {
+      sourceHeaders?: Record<string, unknown>;
+      target: TTarget;
+    }
+  ): Promise<DoclingJob<SubmitResultForTarget<TTarget, TDocument>>>;
+  submitUrl(
+    url: string,
+    options?: ConvertDocumentsOptions,
+    requestOptions?: SubmitCallOptions & {
+      sourceHeaders?: Record<string, unknown>;
+      target?: undefined;
+    }
+  ): Promise<DoclingJob<AutoSubmitResult<TDocument>>>;
+  submitUrl(
+    url: string,
+    options: ConvertDocumentsOptions = {},
+    requestOptions: SubmitCallOptions & {
+      sourceHeaders?: Record<string, unknown>;
+      target?: SubmitTarget;
+    } = {}
+  ): Promise<DoclingJob<AnySubmitResult<TDocument>>> {
+    const source: HttpSource = {
+      kind: 'http',
+      url,
+      headers: requestOptions.sourceHeaders ?? {},
+    };
+    return this.submitSource(source, {
+      options,
+      ...(requestOptions.target === undefined ? {} : { target: requestOptions.target }),
+      ...(requestOptions.headers === undefined
+        ? {}
+        : { headers: requestOptions.headers }),
+      ...(requestOptions.signal === undefined ? {} : { signal: requestOptions.signal }),
+    }) as Promise<DoclingJob<AnySubmitResult<TDocument>>>;
+  }
+
+  submitFile<TTarget extends SubmitTarget>(
+    base64: string,
+    filename: string,
+    options: ConvertDocumentsOptions,
+    requestOptions: SubmitCallOptions & { target: TTarget }
+  ): Promise<DoclingJob<SubmitResultForTarget<TTarget, TDocument>>>;
+  submitFile(
+    base64: string,
+    filename: string,
+    options?: ConvertDocumentsOptions,
+    requestOptions?: SubmitCallOptions & { target?: undefined }
+  ): Promise<DoclingJob<AutoSubmitResult<TDocument>>>;
+  submitFile(
+    base64: string,
+    filename: string,
+    options: ConvertDocumentsOptions = {},
+    requestOptions: SubmitCallOptions & { target?: SubmitTarget } = {}
+  ): Promise<DoclingJob<AnySubmitResult<TDocument>>> {
+    const source: FileSource = {
+      kind: 'file',
+      base64_string: base64,
+      filename,
+    };
+    return this.submitSource(source, {
+      options,
+      ...requestOptions,
+    }) as Promise<DoclingJob<AnySubmitResult<TDocument>>>;
+  }
+
+  submitBinary<TTarget extends SubmitTarget>(
+    source: BinaryFileSource,
+    options: SubmitSourceOptions<TTarget> & { target: TTarget }
+  ): Promise<DoclingJob<SubmitResultForTarget<TTarget, TDocument>>>;
+  submitBinary(
+    source: BinaryFileSource,
+    options?: SubmitSourceOptions & { target?: undefined }
+  ): Promise<DoclingJob<AutoSubmitResult<TDocument>>>;
+  submitBinary(
+    source: BinaryFileSource,
+    options: SubmitSourceOptions = {}
+  ): Promise<DoclingJob<AnySubmitResult<TDocument>>> {
+    return this.submitSource(source, options);
+  }
+
+  async submitBatch<TTarget extends BatchTarget>(
+    request: BatchConvertSourcesRequest<TTarget>,
+    options: BatchSubmitCallOptions = {}
+  ): Promise<DoclingJob<BatchResultForTarget<TTarget>>> {
+    throwIfAborted(options.signal);
+    validateBatchRequest(request);
+    let convertOptions = resolveConvertOptions(this.#defaultOptions, request.options);
+    if (options.outputFormats !== undefined) {
+      convertOptions = {
+        ...convertOptions,
+        to_formats: [...options.outputFormats],
+      };
+      validateConvertOptions(convertOptions);
+    }
+    const payload: BatchConvertSourcesRequest<TTarget> = {
+      options: convertOptions,
+      sources: structuredClone(request.sources),
+      target: structuredClone(request.target),
+      callbacks: structuredClone(request.callbacks ?? []),
+    };
+    throwIfAborted(options.signal);
+    const status = parseTaskStatus(
+      await this.#request<unknown>('POST', '/v1/convert/source/batch', {
+        body: payload,
+        headers: options.headers,
+        signal: options.signal,
+      })
+    );
+    const loader = isPresignedTarget(request.target)
+      ? (
+          taskId: string,
+          lastStatus: TaskStatusResponse | undefined,
+          signal?: AbortSignal
+        ) => this.#fetchPresignedResult(taskId, lastStatus, signal)
+      : (
+          taskId: string,
+          lastStatus: TaskStatusResponse | undefined,
+          signal?: AbortSignal
+        ) => this.#fetchCountsResult(taskId, lastStatus, signal);
+    return new DoclingJob(
+      this,
+      status,
+      loader as ResultLoader<BatchResultForTarget<TTarget>>
+    );
+  }
+
+  async submitChunk(
+    request: ChunkSourcesRequest,
+    options: SubmitCallOptions = {}
+  ): Promise<DoclingJob<ChunkDocumentResponse<TDocument>>> {
+    throwIfAborted(options.signal);
+    if (!Array.isArray(request.sources) || request.sources.length === 0) {
+      throw new DoclingProtocolError('At least one Docling source is required');
+    }
+    if (!['hybrid', 'hierarchical'].includes(request.chunker)) {
+      throw new DoclingProtocolError(
+        `Unsupported Docling chunker: ${String(request.chunker)}`
+      );
+    }
+    validateChunkRequestOptions(request);
+    for (const source of request.sources) {
+      validateConversionSource(source);
+    }
+    validateCallbacks(request.callbacks);
+    if (request.target !== undefined && request.target.kind !== 'inbody') {
+      throw new DoclingProtocolError('Chunk conversion only supports inbody targets');
+    }
+    const payload = {
+      convert_options: resolveConvertOptions(
+        this.#defaultOptions,
+        request.convert_options
+      ),
+      chunking_options: {
+        ...request.chunking_options,
+        chunker: request.chunker,
+      },
+      sources: structuredClone(request.sources),
+      include_converted_doc: request.include_converted_doc ?? false,
+      target: request.target ?? { kind: 'inbody' },
+      callbacks: structuredClone(request.callbacks ?? []),
+    };
+    throwIfAborted(options.signal);
+    const status = parseTaskStatus(
+      await this.#request<unknown>(
+        'POST',
+        `/v1/chunk/${request.chunker}/source/async`,
+        {
+          body: payload,
+          headers: options.headers,
+          signal: options.signal,
+        }
+      )
+    );
+    return new DoclingJob(this, status, (taskId, lastStatus, signal) =>
+      this.#fetchChunkResult(taskId, lastStatus, signal)
+    );
+  }
+
+  submitChunkUrl(
+    url: string,
+    request: ChunkSourceOptions,
+    requestOptions: SubmitCallOptions & {
+      sourceHeaders?: Record<string, unknown>;
+    } = {}
+  ): Promise<DoclingJob<ChunkDocumentResponse<TDocument>>> {
+    return this.submitChunk(
+      {
+        ...request,
+        sources: [
+          {
+            kind: 'http',
+            url,
+            headers: requestOptions.sourceHeaders ?? {},
+          },
+        ],
+      } as ChunkSourcesRequest,
+      requestOptions
+    );
+  }
+
+  submitChunkFile(
+    base64: string,
+    filename: string,
+    request: ChunkSourceOptions,
+    requestOptions: SubmitCallOptions = {}
+  ): Promise<DoclingJob<ChunkDocumentResponse<TDocument>>> {
+    return this.submitChunk(
+      {
+        ...request,
+        sources: [
+          {
+            kind: 'file',
+            base64_string: base64,
+            filename,
+          },
+        ],
+      } as ChunkSourcesRequest,
+      requestOptions
+    );
+  }
+
+  async submitChunkBinary(
+    source: BinaryFileSource,
+    request: ChunkSourceOptions,
+    requestOptions: SubmitCallOptions = {}
+  ): Promise<DoclingJob<ChunkDocumentResponse<TDocument>>> {
+    if (!['hybrid', 'hierarchical'].includes(request.chunker)) {
+      throw new DoclingProtocolError(
+        `Unsupported Docling chunker: ${String(request.chunker)}`
+      );
+    }
+    validateChunkRequestOptions(request);
+    if ((request.callbacks?.length ?? 0) > 0) {
+      throw new DoclingProtocolError(
+        'The multipart chunk endpoint does not support callbacks'
+      );
+    }
+    const normalized = await normalizeSourceInput(source, requestOptions.signal);
+    if (normalized.kind !== 'multipart') {
+      throw new DoclingProtocolError('Binary chunk source normalization failed');
+    }
+    const form = new FormData();
+    const convertOptions = resolveConvertOptions(
+      this.#defaultOptions,
+      request.convert_options
+    );
+    for (const [key, value] of Object.entries(convertOptions)) {
+      if (value !== undefined && value !== null) {
+        form.append(`convert_${key}`, formValue(value));
+      }
+    }
+    for (const [key, value] of Object.entries(request.chunking_options ?? {})) {
+      if (key !== 'chunker' && value !== undefined && value !== null) {
+        form.append(`chunking_${key}`, formValue(value));
+      }
+    }
+    form.append(
+      'include_converted_doc',
+      String(request.include_converted_doc ?? false)
+    );
+    form.append('target_type', 'inbody');
+    form.append('files', normalized.blob, normalized.descriptor.filename);
+    const status = parseTaskStatus(
+      await this.#request<unknown>('POST', `/v1/chunk/${request.chunker}/file/async`, {
+        body: form,
+        bodyType: 'form',
+        headers: requestOptions.headers,
+        signal: requestOptions.signal,
+      })
+    );
+    return new DoclingJob(this, status, (taskId, lastStatus, signal) =>
+      this.#fetchChunkResult(taskId, lastStatus, signal)
+    );
+  }
+
+  job<TResult = InBodyConversionResponse<TDocument>>(
+    taskId: string,
+    status?: TaskStatusResponse,
+    resultLoader?: ResultLoader<TResult>
+  ): DoclingJob<TResult> {
+    if (taskId === '') {
+      throw new DoclingProtocolError('taskId must not be empty');
+    }
+    return new DoclingJob(
+      this,
+      status ?? {
+        task_id: taskId,
+        task_type: 'convert',
+        task_status: 'pending',
+      },
+      resultLoader ??
+        ((id, lastStatus, signal) =>
+          this.#fetchInBodyResult(id, lastStatus, signal) as Promise<TResult>)
+    );
+  }
+
+  async poll(
+    taskId: string,
+    options: { waitSeconds?: number; signal?: AbortSignal } = {}
+  ): Promise<TaskStatusResponse> {
+    requireTaskId(taskId);
+    const waitSeconds = nonNegativeNumber(options.waitSeconds ?? 0, 'waitSeconds');
+    try {
+      return parseTaskStatus(
+        await this.#request<unknown>(
+          'GET',
+          `/v1/status/poll/${encodeURIComponent(taskId)}?wait=${encodeURIComponent(
+            waitSeconds
+          )}`,
+          { signal: options.signal }
+        )
+      );
+    } catch (error) {
+      if (error instanceof DoclingHttpError && error.status === 404) {
+        throw new DoclingTaskNotFoundError(taskId);
+      }
+      throw error;
+    }
+  }
+
+  watch(
+    taskId: string,
+    options: WaitForTaskOptions = {}
+  ): AsyncGenerator<TaskStatusResponse> {
+    if (this.#closed) {
+      throw new DoclingProtocolError('Docling client is closed');
+    }
+    requireTaskId(taskId);
+    return watchTask({
+      taskId,
+      baseUrl: this.#baseUrl,
+      apiKey: this.#apiKey,
+      watcher: options.statusWatcher ?? this.#statusWatcher,
+      fallbackToPoll: this.#webSocketFallbackToPoll,
+      connectTimeoutMs: this.#connectTimeoutMs,
+      ...(this.#webSocketFactory === undefined
+        ? {}
+        : { webSocketFactory: this.#webSocketFactory }),
+      poll: (id, pollOptions) => this.poll(id, pollOptions),
+      parseStatus: parseTaskStatus,
+      timeoutMs: options.timeoutMs ?? this.#jobTimeoutMs,
+      pollIntervalMs: options.pollIntervalMs ?? this.#pollClientIntervalMs,
+      serverWaitSeconds: options.serverWaitSeconds ?? this.#pollServerWaitSeconds,
+      ...(options.signal === undefined ? {} : { signal: options.signal }),
+      ...(options.onStatus === undefined ? {} : { onStatus: options.onStatus }),
+    });
+  }
+
+  async waitForCompletion(
+    taskId: string,
+    options: WaitForTaskOptions = {}
+  ): Promise<TaskStatusResponse> {
+    let lastStatus: TaskStatusResponse | undefined;
+    for await (const status of this.watch(taskId, options)) {
+      lastStatus = status;
+    }
+    if (lastStatus === undefined) {
+      throw new DoclingTimeoutError(taskId, options.timeoutMs ?? this.#jobTimeoutMs);
+    }
+    return lastStatus;
+  }
+
+  getResult(
+    taskId: string,
+    options: { signal?: AbortSignal; lastStatus?: TaskStatusResponse } = {}
+  ): Promise<InBodyConversionResponse<TDocument>> {
+    return this.#fetchInBodyResult(taskId, options.lastStatus, options.signal);
+  }
+
+  getBinaryResult(
+    taskId: string,
+    options: { signal?: AbortSignal; lastStatus?: TaskStatusResponse } = {}
+  ): Promise<RawServiceResult> {
+    return this.#fetchBinaryResult(taskId, options.lastStatus, options.signal);
+  }
+
+  getRawResult<TResult = unknown>(
+    taskId: string,
+    options: { signal?: AbortSignal; lastStatus?: TaskStatusResponse } = {}
+  ): Promise<TResult> {
+    return this.#fetchJsonResult(
+      taskId,
+      options.lastStatus,
+      options.signal
+    ) as Promise<TResult>;
+  }
+
+  async convert(
+    source: ConversionSourceInput,
+    options: ConvertOptions = {}
+  ): Promise<ConversionResult<TDocument>> {
+    const normalized = await normalizeSourceInput(source, options.signal);
+    validateMaxFileSize(options.maxFileSize);
+    let convertOptions = resolveConvertOptions(this.#defaultOptions, options.options);
+    convertOptions = applyPageLimits(
+      convertOptions,
+      options.pageRange,
+      options.maxNumPages
+    );
+    convertOptions = withJsonOutput(convertOptions);
+    const preflight = preflightFileSize(normalized, options.maxFileSize);
+    let result: ConversionResult<TDocument>;
+    if (preflight !== null) {
+      result = syntheticConversion(
+        normalized.descriptor,
+        'skipped',
+        preflight,
+        'policy'
+      );
+    } else {
+      const job = await this.#submitNormalizedWithAutoTarget(
+        normalized,
+        convertOptions,
+        options
+      );
+      const response = await job.result(options);
+      result = isPresignedResponse(response)
+        ? await materializePresignedResult(
+            response,
+            normalized.descriptor,
+            this.#artifactDownloader,
+            options.signal
+          )
+        : response;
+    }
+
+    if (
+      (options.raisesOnError ?? true) &&
+      !['success', 'partial_success'].includes(result.status)
+    ) {
+      throw new DoclingConversionError(conversionFailureMessage(result));
+    }
+    return result;
+  }
+
+  async *convertAll(
+    sources: Iterable<ConversionSourceInput> | AsyncIterable<ConversionSourceInput>,
+    options: ConvertAllOptions = {}
+  ): AsyncGenerator<ConversionResult<TDocument>> {
+    const items = mapSourcesToItems(sources, options.options, options.headers);
+    for await (const completed of boundedOutcomes(
+      items,
+      async (item, _index, signal) => {
+        try {
+          return await this.convert(item.source, {
+            ...options,
+            options: item.options,
+            headers: item.headers,
+            raisesOnError: false,
+            signal,
+          });
+        } catch (error) {
+          if (signal.aborted || isAbortError(error)) {
+            throw signal.reason ?? error;
+          }
+          return syntheticConversion<TDocument>(
+            fallbackInput(item.source),
+            'failure',
+            error instanceof Error ? error.message : String(error)
+          );
+        }
+      },
+      {
+        maxInFlight: validateConcurrency(
+          options.maxConcurrency ?? this.#maxConcurrency
+        ),
+        ordered: true,
+        ...(options.signal === undefined ? {} : { signal: options.signal }),
+      }
+    )) {
+      if (completed.outcome instanceof Error) {
+        yield syntheticConversion<TDocument>(
+          fallbackInput(completed.item.source),
+          'failure',
+          completed.outcome.message
+        );
+      } else {
+        yield completed.outcome;
+      }
+    }
+  }
+
+  submitAndRetrieveEach<TMetadata = unknown>(
+    items:
+      | Iterable<ConversionItem & { metadata?: TMetadata }>
+      | AsyncIterable<ConversionItem & { metadata?: TMetadata }>,
+    options?: Omit<SubmitAndRetrieveOptions<PresignedUrlTarget>, 'target'> & {
+      target?: undefined;
+    }
+  ): AsyncGenerator<
+    [ConversionItem & { metadata?: TMetadata }, AutoSubmitResult<TDocument> | Error]
+  >;
+  submitAndRetrieveEach<
+    TMetadata = unknown,
+    TTarget extends SubmitTarget = SubmitTarget,
+  >(
+    items:
+      | Iterable<ConversionItem & { metadata?: TMetadata }>
+      | AsyncIterable<ConversionItem & { metadata?: TMetadata }>,
+    options: SubmitAndRetrieveOptions<TTarget> & { target: TTarget }
+  ): AsyncGenerator<
+    [
+      ConversionItem & { metadata?: TMetadata },
+      SubmitResultForTarget<TTarget, TDocument> | Error,
+    ]
+  >;
+  async *submitAndRetrieveEach<
+    TMetadata = unknown,
+    TTarget extends SubmitTarget = SubmitTarget,
+  >(
+    items:
+      | Iterable<ConversionItem & { metadata?: TMetadata }>
+      | AsyncIterable<ConversionItem & { metadata?: TMetadata }>,
+    options: SubmitAndRetrieveOptions<TTarget> = {}
+  ): AsyncGenerator<
+    [
+      ConversionItem & { metadata?: TMetadata },
+      AutoSubmitResult<TDocument> | SubmitResultForTarget<TTarget, TDocument> | Error,
+    ]
+  > {
+    const maxInFlight = validateConcurrency(
+      options.maxInFlight ?? DEFAULT_MAX_CONCURRENCY
+    );
+    for await (const completed of boundedOutcomes(
+      items,
+      async (item, _index, signal) => {
+        const job = await this.submitSource(item.source, {
+          options: item.options,
+          ...(item.headers === undefined ? {} : { headers: item.headers }),
+          ...(options.target === undefined ? {} : { target: options.target }),
+          signal,
+        });
+        return job.result({
+          timeoutMs: this.#jobTimeoutMs,
+          ...(maxInFlight > 64 && this.#statusWatcher === 'websocket'
+            ? { statusWatcher: 'polling' as const }
+            : {}),
+          signal,
+        }) as Promise<
+          AutoSubmitResult<TDocument> | SubmitResultForTarget<TTarget, TDocument>
+        >;
+      },
+      {
+        maxInFlight,
+        ordered: options.ordered ?? false,
+        ...(options.signal === undefined ? {} : { signal: options.signal }),
+      }
+    )) {
+      yield [completed.item, completed.outcome];
+    }
+  }
+
+  /** @deprecated Use submitAndRetrieveEach instead. */
+  submitAndRetrieveMany<TMetadata = unknown>(
+    items:
+      | Iterable<ConversionItem & { metadata?: TMetadata }>
+      | AsyncIterable<ConversionItem & { metadata?: TMetadata }>,
+    options?: Omit<SubmitAndRetrieveOptions<PresignedUrlTarget>, 'target'> & {
+      target?: undefined;
+    }
+  ): AsyncGenerator<
+    [ConversionItem & { metadata?: TMetadata }, AutoSubmitResult<TDocument> | Error]
+  >;
+  submitAndRetrieveMany<
+    TMetadata = unknown,
+    TTarget extends SubmitTarget = SubmitTarget,
+  >(
+    items:
+      | Iterable<ConversionItem & { metadata?: TMetadata }>
+      | AsyncIterable<ConversionItem & { metadata?: TMetadata }>,
+    options: SubmitAndRetrieveOptions<TTarget> & { target: TTarget }
+  ): AsyncGenerator<
+    [
+      ConversionItem & { metadata?: TMetadata },
+      SubmitResultForTarget<TTarget, TDocument> | Error,
+    ]
+  >;
+  submitAndRetrieveMany<
+    TMetadata = unknown,
+    TTarget extends SubmitTarget = SubmitTarget,
+  >(
+    items:
+      | Iterable<ConversionItem & { metadata?: TMetadata }>
+      | AsyncIterable<ConversionItem & { metadata?: TMetadata }>,
+    options: SubmitAndRetrieveOptions<TTarget> = {}
+  ): AsyncGenerator<
+    [
+      ConversionItem & { metadata?: TMetadata },
+      AutoSubmitResult<TDocument> | SubmitResultForTarget<TTarget, TDocument> | Error,
+    ]
+  > {
+    return this.submitAndRetrieveEach(
+      items,
+      options as SubmitAndRetrieveOptions<PresignedUrlTarget> & {
+        target?: undefined;
+      }
+    );
+  }
+
+  async chunk(
+    request: ChunkSourcesRequest,
+    waitOptions?: WaitForTaskOptions
+  ): Promise<ChunkDocumentResponse<TDocument>>;
+  async chunk(
+    source: ConversionSourceInput,
+    request: ChunkSourceOptions,
+    waitOptions?: WaitForTaskOptions
+  ): Promise<ChunkDocumentResponse<TDocument>>;
+  async chunk(
+    source: ConversionSourceInput,
+    chunker: ChunkerKind,
+    options?: ConvertDocumentsOptions,
+    waitOptions?: ChunkCallOptions
+  ): Promise<ChunkDocumentResponse<TDocument>>;
+  async chunk(
+    sourceOrRequest: ConversionSourceInput | ChunkSourcesRequest,
+    chunkerOrOptions: ChunkSourceOptions | ChunkerKind | WaitForTaskOptions = {},
+    convertOrWaitOptions: ConvertDocumentsOptions | WaitForTaskOptions = {},
+    explicitWaitOptions: ChunkCallOptions = {}
+  ): Promise<ChunkDocumentResponse<TDocument>> {
+    if (isChunkSourcesRequest(sourceOrRequest)) {
+      const job = await this.submitChunk(sourceOrRequest, {
+        signal: (chunkerOrOptions as WaitForTaskOptions).signal,
+      });
+      return job.result(chunkerOrOptions as WaitForTaskOptions);
+    }
+    const pythonShaped = typeof chunkerOrOptions === 'string';
+    const request: ChunkSourceOptions = pythonShaped
+      ? {
+          chunker: chunkerOrOptions,
+          convert_options: convertOrWaitOptions as ConvertDocumentsOptions,
+          include_converted_doc: explicitWaitOptions.includeConvertedDoc ?? false,
+        }
+      : (chunkerOrOptions as ChunkSourceOptions);
+    const waitOptions = pythonShaped
+      ? explicitWaitOptions
+      : (convertOrWaitOptions as WaitForTaskOptions);
+    const normalized = await normalizeSourceInput(sourceOrRequest, waitOptions.signal);
+    const job =
+      normalized.kind === 'multipart'
+        ? await this.submitChunkBinary(
+            {
+              data: normalized.blob,
+              filename: normalized.descriptor.filename,
+              contentType: normalized.blob.type,
+            },
+            request,
+            { signal: waitOptions.signal }
+          )
+        : await this.submitChunk(
+            {
+              ...request,
+              sources: [normalized.source],
+            } as ChunkSourcesRequest,
+            { signal: waitOptions.signal }
+          );
+    return job.result(waitOptions);
+  }
+
+  #submitWithAutoTarget(
+    request: ConvertSourcesRequest,
+    options: SubmitCallOptions
+  ): Promise<DoclingJob<AutoSubmitResult<TDocument>>> {
+    return this.#submitRequestForTarget(
+      {
+        ...request,
+        options: request.options ?? {},
+        target: { kind: 'presigned_url' },
+      },
+      options
+    ).catch(error => {
+      if (!shouldFallbackFromPresigned(error)) {
+        throw error;
+      }
+      return this.#submitRequestForTarget(
+        {
+          ...request,
+          options: withJsonOutput(request.options ?? {}),
+          target: { kind: 'inbody' },
+        },
+        options
+      );
+    }) as Promise<DoclingJob<AutoSubmitResult<TDocument>>>;
+  }
+
+  #submitNormalizedWithAutoTarget(
+    source: NormalizedSource,
+    options: ConvertDocumentsOptions,
+    requestOptions: SubmitCallOptions
+  ): Promise<DoclingJob<AutoSubmitResult<TDocument>>> {
+    return this.#submitNormalizedForTarget(
+      source,
+      options,
+      { kind: 'presigned_url' },
+      requestOptions
+    ).catch(error => {
+      if (!shouldFallbackFromPresigned(error)) {
+        throw error;
+      }
+      return this.#submitNormalizedForTarget(
+        source,
+        withJsonOutput(options),
+        { kind: 'inbody' },
+        requestOptions
+      );
+    }) as Promise<DoclingJob<AutoSubmitResult<TDocument>>>;
+  }
+
+  async #submitRequestForTarget<TTarget extends SubmitTarget>(
+    request: ConvertSourcesRequest<TTarget> & { target: TTarget },
+    options: SubmitCallOptions
+  ): Promise<DoclingJob<SubmitResultForTarget<TTarget, TDocument>>> {
+    validateConversionSource(request.sources[0]);
+    validateSubmitTarget(request.target);
+    validateCallbacks(request.callbacks);
+    const descriptor = (await normalizeSourceInput(request.sources[0], options.signal))
+      .descriptor;
+    const payload = {
+      options: request.options ?? {},
+      sources: structuredClone(request.sources),
+      target: structuredClone(request.target),
+      callbacks: structuredClone(request.callbacks ?? []),
+    };
+    throwIfAborted(options.signal);
+    const status = parseTaskStatus(
+      await this.#request<unknown>('POST', '/v1/convert/source/async', {
+        body: payload,
+        headers: options.headers,
+        signal: options.signal,
+      })
+    );
+    return new DoclingJob(
+      this,
+      status,
+      this.#resultLoaderForTarget(request.target, descriptor)
+    );
+  }
+
+  async #submitNormalizedForTarget<TTarget extends SubmitTarget>(
+    source: NormalizedSource,
+    options: ConvertDocumentsOptions,
+    target: TTarget,
+    requestOptions: SubmitCallOptions
+  ): Promise<DoclingJob<SubmitResultForTarget<TTarget, TDocument>>> {
+    if (source.kind === 'json') {
+      return this.#submitRequestForTarget(
+        {
+          options,
+          sources: [source.source],
+          target,
+          callbacks: [],
+        },
+        requestOptions
+      );
+    }
+    if (!['inbody', 'zip', 'presigned_url'].includes(target.kind)) {
+      const fileSource = await fileSourceFromBlob(source, requestOptions.signal);
+      return this.#submitRequestForTarget(
+        {
+          options,
+          sources: [fileSource],
+          target,
+          callbacks: [],
+        },
+        requestOptions
+      );
+    }
+    const form = new FormData();
+    for (const [key, value] of Object.entries(options)) {
+      if (value !== undefined && value !== null) {
+        form.append(key, formValue(value));
+      }
+    }
+    form.append('target_type', target.kind);
+    form.append('files', source.blob, source.descriptor.filename);
+    const status = parseTaskStatus(
+      await this.#request<unknown>('POST', '/v1/convert/file/async', {
+        body: form,
+        bodyType: 'form',
+        headers: requestOptions.headers,
+        signal: requestOptions.signal,
+      })
+    );
+    return new DoclingJob(
+      this,
+      status,
+      this.#resultLoaderForTarget(target, source.descriptor)
+    );
+  }
+
+  #resultLoaderForTarget<TTarget extends SubmitTarget>(
+    target: TTarget,
+    descriptor: ConversionInput
+  ): ResultLoader<SubmitResultForTarget<TTarget, TDocument>> {
+    if (target.kind === 'zip') {
+      return ((taskId, lastStatus, signal) =>
+        this.#fetchBinaryResult(taskId, lastStatus, signal)) as ResultLoader<
+        SubmitResultForTarget<TTarget, TDocument>
+      >;
+    }
+    if (target.kind === 'presigned_url') {
+      return ((taskId, lastStatus, signal) =>
+        this.#fetchPresignedResult(taskId, lastStatus, signal)) as ResultLoader<
+        SubmitResultForTarget<TTarget, TDocument>
+      >;
+    }
+    if (target.kind !== 'inbody') {
+      return ((taskId, lastStatus, signal) =>
+        this.#fetchCountsResult(taskId, lastStatus, signal)) as ResultLoader<
+        SubmitResultForTarget<TTarget, TDocument>
+      >;
+    }
+    return (async (taskId, lastStatus, signal) =>
+      conversionFromResponse(
+        await this.#fetchConvertResult(taskId, lastStatus, signal),
+        descriptor
+      )) as ResultLoader<SubmitResultForTarget<TTarget, TDocument>>;
+  }
+
+  async #fetchJsonResult(
+    taskId: string,
+    lastStatus?: TaskStatusResponse,
+    signal?: AbortSignal
+  ): Promise<unknown> {
+    requireTaskId(taskId);
+    try {
+      const result = await this.#request<unknown>(
+        'GET',
+        `/v1/result/${encodeURIComponent(taskId)}`,
+        { signal }
+      );
+      if (isTaskFailureResult(result)) {
+        throw new DoclingTaskError({
+          task_id: taskId,
+          task_type: lastStatus?.task_type ?? 'convert',
+          task_status: 'failure',
+          failure: result.failure,
+        });
+      }
+      return result;
+    } catch (error) {
+      if (error instanceof DoclingHttpError && error.status === 404) {
+        throw mapResultNotFound(taskId, error, lastStatus);
+      }
+      if (error instanceof DoclingProtocolError) {
+        throw new DoclingResponseSchemaMismatchError(
+          'Docling result response is not valid JSON',
+          { status: 200, cause: error }
+        );
+      }
+      throw error;
+    }
+  }
+
+  async #fetchConvertResult(
+    taskId: string,
+    lastStatus?: TaskStatusResponse,
+    signal?: AbortSignal
+  ): Promise<ConvertDocumentResponse<TDocument>> {
+    const result = await this.#fetchJsonResult(taskId, lastStatus, signal);
+    return parseConvertDocumentResponse<TDocument>(result);
+  }
+
+  async #fetchChunkResult(
+    taskId: string,
+    lastStatus?: TaskStatusResponse,
+    signal?: AbortSignal
+  ): Promise<ChunkDocumentResponse<TDocument>> {
+    const result = await this.#fetchJsonResult(taskId, lastStatus, signal);
+    return parseChunkDocumentResponse<TDocument>(result);
+  }
+
+  async #fetchInBodyResult(
+    taskId: string,
+    lastStatus?: TaskStatusResponse,
+    signal?: AbortSignal
+  ): Promise<InBodyConversionResponse<TDocument>> {
+    const result = await this.#fetchJsonResult(taskId, lastStatus, signal);
+    if (
+      isConvertDocumentResponse<TDocument>(result) ||
+      isChunkDocumentResponse<TDocument>(result)
+    ) {
+      return isConvertDocumentResponse<TDocument>(result)
+        ? parseConvertDocumentResponse<TDocument>(result)
+        : parseChunkDocumentResponse<TDocument>(result);
+    }
+    throw new DoclingResponseSchemaMismatchError(
+      'Docling returned an unknown in-body result response',
+      { status: 200 }
+    );
+  }
+
+  async #fetchPresignedResult(
+    taskId: string,
+    lastStatus?: TaskStatusResponse,
+    signal?: AbortSignal
+  ): Promise<PresignedUrlConvertResponse> {
+    const result = await this.#fetchJsonResult(taskId, lastStatus, signal);
+    return parsePresignedResponse(result);
+  }
+
+  async #fetchCountsResult(
+    taskId: string,
+    lastStatus?: TaskStatusResponse,
+    signal?: AbortSignal
+  ): Promise<PresignedUrlConvertDocumentResponse> {
+    const result = await this.#fetchJsonResult(taskId, lastStatus, signal);
+    return parseCountsResponse(result);
+  }
+
+  async #fetchBinaryResult(
+    taskId: string,
+    lastStatus?: TaskStatusResponse,
+    signal?: AbortSignal
+  ): Promise<RawServiceResult> {
+    requireTaskId(taskId);
+    try {
+      const response = await this.#request<DoclingBinaryResponse>(
+        'GET',
+        `/v1/result/${encodeURIComponent(taskId)}`,
+        { responseType: 'bytes', signal }
+      );
+      if (response.contentType.toLowerCase().includes('json')) {
+        let json: unknown | undefined;
+        try {
+          json = JSON.parse(new TextDecoder().decode(response.content)) as unknown;
+        } catch {
+          // Match the Python client's failure-envelope sniff: malformed
+          // JSON-labeled content remains available as a lossless raw result.
+        }
+        if (json !== undefined && isTaskFailureResult(json)) {
+          throw new DoclingTaskError({
+            task_id: taskId,
+            task_type: lastStatus?.task_type ?? 'convert',
+            task_status: 'failure',
+            failure: json.failure,
+          });
+        }
+      }
+      return {
+        content: response.content,
+        content_type: response.contentType || 'application/octet-stream',
+        filename: filenameFromContentDisposition(
+          response.headers['content-disposition']
+        ),
+      };
+    } catch (error) {
+      if (error instanceof DoclingHttpError && error.status === 404) {
+        throw mapResultNotFound(taskId, error, lastStatus);
+      }
+      throw error;
+    }
+  }
+
+  #request<T>(
+    method: DoclingTransportRequest['method'],
+    path: string,
+    options: {
+      body?: unknown;
+      bodyType?: DoclingRequestBodyType;
+      responseType?: DoclingResponseType;
+      headers?: Record<string, string>;
+      retries?: number;
+      timeoutMs?: number;
+      signal?: AbortSignal;
+    } = {}
+  ): Promise<T> {
+    if (this.#closed) {
+      throw new DoclingProtocolError('Docling client is closed');
+    }
+    const headers = {
+      ...this.#headers,
+      ...(options.bodyType === 'form' ? {} : { 'content-type': 'application/json' }),
+      ...normalizeHeaders(options.headers),
+    };
+    if (options.bodyType === 'form') {
+      delete headers['content-type'];
+    }
+    return this.#transport.request<T>({
+      method,
+      url: `${this.#baseUrl}${path}`,
+      headers,
+      ...(options.body === undefined ? {} : { body: options.body }),
+      ...(options.bodyType === undefined ? {} : { bodyType: options.bodyType }),
+      ...(options.responseType === undefined
+        ? {}
+        : { responseType: options.responseType }),
+      ...(options.retries === undefined ? {} : { retries: options.retries }),
+      ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
+      ...(options.signal === undefined ? {} : { signal: options.signal }),
+    });
+  }
+}
+
+type ResultLoader<TResult> = (
+  taskId: string,
+  lastStatus?: TaskStatusResponse,
+  signal?: AbortSignal
+) => Promise<TResult>;
+
+export class DoclingJob<TResult> {
+  readonly #client: DoclingClient<unknown>;
+  readonly #submittedAt: Date;
+  readonly #loadResult: ResultLoader<TResult>;
+  #status: TaskStatusResponse;
+
+  constructor(
+    client: DoclingClient<unknown>,
+    status: TaskStatusResponse,
+    loadResult: ResultLoader<TResult>
+  ) {
+    this.#client = client;
+    this.#status = status;
+    this.#loadResult = loadResult;
+    this.#submittedAt = new Date();
+  }
+
+  get taskId(): string {
+    return this.#status.task_id;
+  }
+
+  get status(): TaskStatusResponse {
+    return this.#status;
+  }
+
+  get submittedAt(): Date {
+    return new Date(this.#submittedAt);
+  }
+
+  get queuePosition(): number | null {
+    return this.#status.task_position ?? null;
+  }
+
+  get done(): boolean {
+    return ['success', 'failure'].includes(this.#status.task_status);
+  }
+
+  async poll(
+    options: { waitSeconds?: number; signal?: AbortSignal } = {}
+  ): Promise<TaskStatusResponse> {
+    this.#status = await this.#client.poll(this.taskId, options);
+    return this.#status;
+  }
+
+  async *watch(options: WaitForTaskOptions = {}): AsyncGenerator<TaskStatusResponse> {
+    for await (const status of this.#client.watch(this.taskId, options)) {
+      this.#status = status;
+      yield status;
+    }
+  }
+
+  async wait(options: WaitForTaskOptions = {}): Promise<TaskStatusResponse> {
+    if (!this.done) {
+      this.#status = await this.#client.waitForCompletion(this.taskId, options);
+    }
+    return this.#status;
+  }
+
+  getResult(options: { signal?: AbortSignal } = {}): Promise<TResult> {
+    return this.#loadResult(this.taskId, this.#status, options.signal);
+  }
+
+  async result(options: WaitForTaskOptions = {}): Promise<TResult> {
+    if (!this.done) {
+      await this.wait(options);
+    }
+    return this.getResult({ signal: options.signal });
+  }
+}
+
+function parseTaskStatus(value: unknown): TaskStatusResponse {
+  if (!isRecord(value)) {
+    throw schemaMismatch('Docling returned a non-object task status');
+  }
+  if (typeof value.task_id !== 'string' || value.task_id === '') {
+    throw schemaMismatch('Docling task status is missing task_id');
+  }
+  if (!['convert', 'chunk'].includes(String(value.task_type))) {
+    throw schemaMismatch('Docling task status is missing task_type');
+  }
+  if (
+    ![
+      'pending',
+      'started',
+      'success',
+      'failure',
+      'partial_success',
+      'skipped',
+    ].includes(String(value.task_status))
+  ) {
+    throw schemaMismatch(
+      `Docling returned unknown task_status: ${String(value.task_status)}`
+    );
+  }
+  validateOptionalNullableInteger(value.task_position, 'task_position');
+  validateOptionalNullableString(value.error_message, 'error_message');
+  let taskMeta: TaskStatusResponse['task_meta'] = value.task_meta as
+    | TaskStatusResponse['task_meta']
+    | undefined;
+  if (value.task_meta !== undefined && value.task_meta !== null) {
+    if (!isRecord(value.task_meta)) {
+      throw schemaMismatch('Docling task_meta must be an object or null');
+    }
+    requireInteger(value.task_meta.num_docs, 'task_meta.num_docs');
+    for (const field of [
+      'num_processed',
+      'num_succeeded',
+      'num_partially_succeeded',
+      'num_failed',
+    ]) {
+      if (value.task_meta[field] !== undefined) {
+        requireInteger(value.task_meta[field], `task_meta.${field}`);
+      }
+    }
+    taskMeta = {
+      num_docs: value.task_meta.num_docs as number,
+      num_processed: (value.task_meta.num_processed as number | undefined) ?? 0,
+      num_succeeded: (value.task_meta.num_succeeded as number | undefined) ?? 0,
+      num_partially_succeeded:
+        (value.task_meta.num_partially_succeeded as number | undefined) ?? 0,
+      num_failed: (value.task_meta.num_failed as number | undefined) ?? 0,
+    };
+  }
+  let failure: TaskStatusResponse['failure'] = value.failure as
+    | TaskStatusResponse['failure']
+    | undefined;
+  if (value.failure !== undefined && value.failure !== null) {
+    failure = parseFailureInfo(value.failure);
+  }
+  return {
+    ...(value as unknown as TaskStatusResponse),
+    ...(value.task_meta === undefined ? {} : { task_meta: taskMeta }),
+    ...(value.failure === undefined ? {} : { failure }),
+  };
+}
+
+function isConvertDocumentResponse<TDocument>(
+  value: unknown
+): value is ConvertDocumentResponse<TDocument> {
+  if (!isRecord(value) || !('document' in value)) {
+    return false;
+  }
+  try {
+    parseConvertDocumentResponse<TDocument>(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isChunkDocumentResponse<TDocument>(
+  value: unknown
+): value is ChunkDocumentResponse<TDocument> {
+  if (!isRecord(value) || !('chunks' in value)) {
+    return false;
+  }
+  try {
+    parseChunkDocumentResponse<TDocument>(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isCountsResponse(
+  value: unknown
+): value is PresignedUrlConvertDocumentResponse {
+  if (!isRecord(value)) {
+    return false;
+  }
+  try {
+    parseCountsResponse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isPresignedResponse(value: unknown): value is PresignedUrlConvertResponse {
+  return isCountsResponse(value) && isRecord(value) && Array.isArray(value.documents);
+}
+
+function isTaskFailureResult(value: unknown): value is TaskFailureResult {
+  if (!isRecord(value) || value.kind !== 'TaskFailureResult') {
+    return false;
+  }
+  try {
+    parseFailureInfo(value.failure);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isConversionStatus(value: unknown): boolean {
+  return [
+    'pending',
+    'started',
+    'success',
+    'partial_success',
+    'skipped',
+    'failure',
+  ].includes(String(value));
+}
+
+function parseConvertDocumentResponse<TDocument>(
+  value: unknown
+): ConvertDocumentResponse<TDocument> {
+  if (!isRecord(value) || !isRecord(value.document)) {
+    throw schemaMismatch('Docling conversion response is missing its document object');
+  }
+  const document = value.document;
+  if (typeof document.filename !== 'string') {
+    throw schemaMismatch('Docling conversion document filename must be a string');
+  }
+  for (const field of [
+    'md_content',
+    'html_content',
+    'text_content',
+    'doctags_content',
+    'doclang_content',
+  ]) {
+    validateOptionalNullableString(document[field], `document.${field}`);
+  }
+  if (
+    document.json_content !== undefined &&
+    document.json_content !== null &&
+    !isDoclingDocument(document.json_content)
+  ) {
+    throw schemaMismatch('document.json_content is not a DoclingDocument');
+  }
+  requireConversionStatus(value.status, 'status');
+  requireFiniteNumber(value.processing_time, 'processing_time');
+  const errors = parseErrors(value.errors);
+  const timings = parseTimings(value.timings);
+  const confidence = parseConfidence(value.confidence, 'confidence');
+  return {
+    document: document as unknown as ConvertDocumentResponse<TDocument>['document'],
+    status: value.status as ConvertDocumentResponse<TDocument>['status'],
+    errors,
+    processing_time: value.processing_time,
+    timings,
+    ...(value.confidence === undefined ? {} : { confidence }),
+  };
+}
+
+function parseChunkDocumentResponse<TDocument>(
+  value: unknown
+): ChunkDocumentResponse<TDocument> {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.chunks) ||
+    !Array.isArray(value.documents)
+  ) {
+    throw schemaMismatch('Docling chunk response must contain arrays');
+  }
+  requireFiniteNumber(value.processing_time, 'processing_time');
+  const chunks = value.chunks.map((chunk, index) => {
+    if (!isRecord(chunk)) {
+      throw schemaMismatch(`chunks[${index}] must be an object`);
+    }
+    requireString(chunk.filename, `chunks[${index}].filename`);
+    requireInteger(chunk.chunk_index, `chunks[${index}].chunk_index`);
+    requireString(chunk.text, `chunks[${index}].text`);
+    if (
+      !Array.isArray(chunk.doc_items) ||
+      chunk.doc_items.some(item => typeof item !== 'string')
+    ) {
+      throw schemaMismatch(`chunks[${index}].doc_items must be strings`);
+    }
+    validateOptionalNullableString(chunk.raw_text, `chunks[${index}].raw_text`);
+    validateOptionalNullableInteger(chunk.num_tokens, `chunks[${index}].num_tokens`);
+    validateOptionalNullableStringArray(chunk.headings, `chunks[${index}].headings`);
+    validateOptionalNullableStringArray(chunk.captions, `chunks[${index}].captions`);
+    if (
+      chunk.page_numbers !== undefined &&
+      chunk.page_numbers !== null &&
+      (!Array.isArray(chunk.page_numbers) ||
+        chunk.page_numbers.some(page => !Number.isSafeInteger(page)))
+    ) {
+      throw schemaMismatch(`chunks[${index}].page_numbers must be integers`);
+    }
+    validateOptionalRecordOrNull(chunk.metadata, `chunks[${index}].metadata`);
+    return chunk as unknown as ChunkDocumentResponse<TDocument>['chunks'][number];
+  });
+  const documents = value.documents.map((document, index) =>
+    parseExportResult<TDocument>(document, `documents[${index}]`)
+  );
+  return {
+    chunks,
+    documents,
+    processing_time: value.processing_time,
+  };
+}
+
+function parseExportResult<TDocument>(
+  value: unknown,
+  path: string
+): ChunkDocumentResponse<TDocument>['documents'][number] {
+  if (!isRecord(value)) {
+    throw schemaMismatch(`${path} must be an object`);
+  }
+  if (value.kind !== undefined && value.kind !== 'ExportResult') {
+    throw schemaMismatch(`${path}.kind must be ExportResult`);
+  }
+  const document = value.content ?? value.document;
+  const parsed = parseConvertDocumentResponse<TDocument>({
+    document,
+    status: value.status,
+    errors: value.errors,
+    timings: value.timings,
+    confidence: value.confidence,
+    processing_time: 0,
+  });
+  return {
+    kind: 'ExportResult',
+    content: parsed.document,
+    status: parsed.status,
+    errors: parsed.errors,
+    timings: parsed.timings,
+    ...(parsed.confidence === undefined ? {} : { confidence: parsed.confidence }),
+  };
+}
+
+function parseCountsResponse(value: unknown): PresignedUrlConvertDocumentResponse {
+  if (!isRecord(value)) {
+    throw schemaMismatch('Docling remote-target result must be an object');
+  }
+  for (const field of ['num_converted', 'num_succeeded', 'num_failed']) {
+    requireInteger(value[field], field);
+  }
+  if (value.num_partially_succeeded !== undefined) {
+    requireInteger(value.num_partially_succeeded, 'num_partially_succeeded');
+  }
+  requireFiniteNumber(value.processing_time, 'processing_time');
+  return {
+    num_converted: value.num_converted as number,
+    num_succeeded: value.num_succeeded as number,
+    num_partially_succeeded: (value.num_partially_succeeded as number | undefined) ?? 0,
+    num_failed: value.num_failed as number,
+    processing_time: value.processing_time,
+  };
+}
+
+function parsePresignedResponse(value: unknown): PresignedUrlConvertResponse {
+  const counts = parseCountsResponse(value);
+  if (!isRecord(value) || !Array.isArray(value.documents)) {
+    throw schemaMismatch('Docling presigned result must contain documents');
+  }
+  const documents = value.documents.map((item, index) => {
+    const path = `documents[${index}]`;
+    if (!isRecord(item)) {
+      throw schemaMismatch(`${path} must be an object`);
+    }
+    requireInteger(item.source_index, `${path}.source_index`);
+    requireString(item.source_uri, `${path}.source_uri`);
+    requireString(item.filename, `${path}.filename`);
+    requireConversionStatus(item.status, `${path}.status`);
+    const errors = parseErrors(item.errors);
+    const timings = parseTimings(item.timings);
+    const confidence = parseConfidence(item.confidence, `${path}.confidence`);
+    const artifactsValue = item.artifacts ?? [];
+    if (!Array.isArray(artifactsValue)) {
+      throw schemaMismatch(`${path}.artifacts must be an array`);
+    }
+    const artifacts = artifactsValue.map((artifact, artifactIndex) => {
+      const artifactPath = `${path}.artifacts[${artifactIndex}]`;
+      if (!isRecord(artifact)) {
+        throw schemaMismatch(`${artifactPath} must be an object`);
+      }
+      if (
+        ![
+          'json',
+          'html',
+          'markdown',
+          'text',
+          'doctags',
+          'doclang',
+          'resource_bundle',
+        ].includes(String(artifact.artifact_type))
+      ) {
+        throw schemaMismatch(`${artifactPath}.artifact_type is unsupported`);
+      }
+      requireString(artifact.mime_type, `${artifactPath}.mime_type`);
+      requireString(artifact.uri, `${artifactPath}.uri`);
+      parseAbsoluteUrl(artifact.uri, `${artifactPath}.uri`);
+      validateOptionalNullableString(
+        artifact.url_expires_at,
+        `${artifactPath}.url_expires_at`
+      );
+      if (
+        typeof artifact.url_expires_at === 'string' &&
+        Number.isNaN(Date.parse(artifact.url_expires_at))
+      ) {
+        throw schemaMismatch(`${artifactPath}.url_expires_at must be a datetime`);
+      }
+      return artifact as unknown as PresignedUrlConvertResponse['documents'][number]['artifacts'][number];
+    });
+    return {
+      source_index: item.source_index as number,
+      source_uri: item.source_uri as string,
+      filename: item.filename as string,
+      status: item.status as PresignedUrlConvertResponse['documents'][number]['status'],
+      errors,
+      timings,
+      artifacts,
+      ...(item.confidence === undefined ? {} : { confidence }),
+    };
+  });
+  return { ...counts, documents };
+}
+
+function parseErrors(value: unknown): ErrorItem[] {
+  const errors = value ?? [];
+  if (!Array.isArray(errors)) {
+    throw schemaMismatch('errors must be an array');
+  }
+  return errors.map((error, index) => {
+    if (!isRecord(error)) {
+      throw schemaMismatch(`errors[${index}] must be an object`);
+    }
+    if (
+      ![
+        'document_backend',
+        'model',
+        'doc_assembler',
+        'user_input',
+        'pipeline',
+      ].includes(String(error.component_type))
+    ) {
+      throw schemaMismatch(`errors[${index}].component_type is unsupported`);
+    }
+    requireString(error.module_name, `errors[${index}].module_name`);
+    requireString(error.error_message, `errors[${index}].error_message`);
+    if (
+      error.category !== undefined &&
+      !FAILURE_CATEGORIES.has(String(error.category))
+    ) {
+      throw schemaMismatch(`errors[${index}].category is unsupported`);
+    }
+    validateOptionalNullableInteger(error.page_no, `errors[${index}].page_no`);
+    return {
+      component_type: error.component_type as ErrorItem['component_type'],
+      module_name: error.module_name,
+      error_message: error.error_message,
+      category: (error.category as FailureCategory | undefined) ?? 'unknown',
+      page_no: (error.page_no as number | null | undefined) ?? null,
+    };
+  });
+}
+
+function parseTimings(value: unknown): Record<string, ProfilingItem> {
+  const timings = value ?? {};
+  if (!isRecord(timings)) {
+    throw schemaMismatch('timings must be an object');
+  }
+  const parsed: Record<string, ProfilingItem> = {};
+  for (const [name, timing] of Object.entries(timings)) {
+    if (!isRecord(timing) || !['page', 'document'].includes(String(timing.scope))) {
+      throw schemaMismatch(`timings.${name}.scope is unsupported`);
+    }
+    if (timing.count !== undefined) {
+      requireInteger(timing.count, `timings.${name}.count`);
+    }
+    const times = timing.times ?? [];
+    if (
+      !Array.isArray(times) ||
+      times.some(time => typeof time !== 'number' || !Number.isFinite(time))
+    ) {
+      throw schemaMismatch(`timings.${name}.times must contain numbers`);
+    }
+    const timestamps = timing.start_timestamps ?? [];
+    if (
+      !Array.isArray(timestamps) ||
+      timestamps.some(timestamp => typeof timestamp !== 'string')
+    ) {
+      throw schemaMismatch(`timings.${name}.start_timestamps must contain strings`);
+    }
+    if (timestamps.some(timestamp => Number.isNaN(Date.parse(timestamp as string)))) {
+      throw schemaMismatch(`timings.${name}.start_timestamps must contain datetimes`);
+    }
+    parsed[name] = {
+      scope: timing.scope as ProfilingItem['scope'],
+      count: (timing.count as number | undefined) ?? 0,
+      times,
+      start_timestamps: timestamps,
+    };
+  }
+  return parsed;
+}
+
+function parseFailureInfo(value: unknown): PublicFailureInfo {
+  if (!isRecord(value)) {
+    throw schemaMismatch('failure must be an object');
+  }
+  if (!FAILURE_CATEGORIES.has(String(value.category))) {
+    throw schemaMismatch('failure.category is unsupported');
+  }
+  requireString(value.message, 'failure.message');
+  if (typeof value.retryable !== 'boolean') {
+    throw schemaMismatch('failure.retryable must be a boolean');
+  }
+  if (
+    !['admission', 'source_enumeration', 'execution', 'orchestration'].includes(
+      String(value.phase)
+    )
+  ) {
+    throw schemaMismatch('failure.phase is unsupported');
+  }
+  const details = value.details ?? {};
+  if (
+    !isRecord(details) ||
+    Object.values(details).some(detail => typeof detail !== 'string')
+  ) {
+    throw schemaMismatch('failure.details must contain string values');
+  }
+  return {
+    category: value.category as FailureCategory,
+    message: value.message,
+    retryable: value.retryable,
+    phase: value.phase as PublicFailureInfo['phase'],
+    details: details as Record<string, string>,
+  };
+}
+
+const FAILURE_CATEGORIES = new Set([
+  'policy',
+  'capacity',
+  'source_unavailable',
+  'target_unavailable',
+  'timeout',
+  'internal',
+  'backend_failure',
+  'inference_failure',
+  'unknown',
+]);
+
+function isDoclingDocument(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    value.schema_name === 'DoclingDocument' &&
+    typeof value.name === 'string'
+  );
+}
+
+function requireConversionStatus(value: unknown, path: string): void {
+  if (!isConversionStatus(value)) {
+    throw schemaMismatch(`${path} is not a conversion status`);
+  }
+}
+
+function requireString(value: unknown, path: string): asserts value is string {
+  if (typeof value !== 'string') {
+    throw schemaMismatch(`${path} must be a string`);
+  }
+}
+
+function requireInteger(value: unknown, path: string): asserts value is number {
+  if (!Number.isSafeInteger(value)) {
+    throw schemaMismatch(`${path} must be an integer`);
+  }
+}
+
+function requireFiniteNumber(value: unknown, path: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw schemaMismatch(`${path} must be a finite number`);
+  }
+}
+
+function validateOptionalNullableString(value: unknown, path: string): void {
+  if (value !== undefined && value !== null && typeof value !== 'string') {
+    throw schemaMismatch(`${path} must be a string or null`);
+  }
+}
+
+function validateOptionalNullableInteger(value: unknown, path: string): void {
+  if (value !== undefined && value !== null && !Number.isSafeInteger(value)) {
+    throw schemaMismatch(`${path} must be an integer or null`);
+  }
+}
+
+function validateOptionalNullableStringArray(value: unknown, path: string): void {
+  if (
+    value !== undefined &&
+    value !== null &&
+    (!Array.isArray(value) || value.some(item => typeof item !== 'string'))
+  ) {
+    throw schemaMismatch(`${path} must contain strings or be null`);
+  }
+}
+
+function validateOptionalRecordOrNull(value: unknown, path: string): void {
+  if (value !== undefined && value !== null && !isRecord(value)) {
+    throw schemaMismatch(`${path} must be an object or null`);
+  }
+}
+
+function parseConfidence(
+  value: unknown,
+  path: string
+): ConfidenceScores | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  if (!isRecord(value)) {
+    throw schemaMismatch(`${path} must be an object or null`);
+  }
+  for (const field of [
+    'parse_score',
+    'layout_score',
+    'table_score',
+    'ocr_score',
+    'mean_score',
+    'low_score',
+  ]) {
+    const score = value[field];
+    if (
+      score !== undefined &&
+      score !== null &&
+      (typeof score !== 'number' || !Number.isFinite(score))
+    ) {
+      throw schemaMismatch(`${path}.${field} must be a number or null`);
+    }
+  }
+  for (const field of ['mean_grade', 'low_grade']) {
+    const grade = value[field];
+    if (
+      grade !== undefined &&
+      !['poor', 'fair', 'good', 'excellent', 'unspecified'].includes(String(grade))
+    ) {
+      throw schemaMismatch(`${path}.${field} is unsupported`);
+    }
+  }
+  return value as ConfidenceScores;
+}
+
+function schemaMismatch(message: string): DoclingResponseSchemaMismatchError {
+  return new DoclingResponseSchemaMismatchError(message, { status: 200 });
+}
+
+function conversionFromResponse<TDocument>(
+  response: ConvertDocumentResponse<TDocument>,
+  input: ConversionInput
+): ConversionResult<TDocument> {
+  return {
+    input: {
+      ...input,
+      filename: response.document.filename || input.filename,
+    },
+    document:
+      response.document.json_content ??
+      emptyDocument<TDocument>(response.document.filename || input.filename),
+    status: response.status,
+    errors: response.errors,
+    processing_time: response.processing_time,
+    timings: response.timings,
+    ...(response.confidence === undefined ? {} : { confidence: response.confidence }),
+  };
+}
+
+function syntheticConversion<TDocument>(
+  input: ConversionInput,
+  status: 'failure' | 'skipped',
+  message: string,
+  category: FailureCategory = 'unknown'
+): ConversionResult<TDocument> {
+  const error: ErrorItem = {
+    component_type: 'user_input',
+    module_name: '@docling/docling-client',
+    error_message: message,
+    category,
+  };
+  return {
+    input,
+    document: emptyDocument<TDocument>(input.filename),
+    status,
+    errors: [error],
+    processing_time: 0,
+    timings: {},
+  };
+}
+
+function emptyDocument<TDocument>(filename: string): TDocument {
+  const leaf = filename.replaceAll('\\', '/').split('/').at(-1) ?? filename;
+  const extension = leaf.lastIndexOf('.');
+  const name = extension > 0 ? leaf.slice(0, extension) : leaf;
+  return {
+    schema_name: 'DoclingDocument',
+    name: name || 'document',
+  } as TDocument;
+}
+
+function conversionFailureMessage<TDocument>(
+  result: ConversionResult<TDocument>
+): string {
+  const errors = result.errors.map(error => error.error_message).join('; ');
+  return `Conversion failed for ${result.input.filename} with status ${result.status}${
+    errors === '' ? '' : `. Errors: ${errors}`
+  }`;
+}
+
+function mapResultNotFound(
+  taskId: string,
+  error: DoclingHttpError,
+  lastStatus?: TaskStatusResponse
+): Error {
+  const detail = httpDetail(error.body);
+  if (detail === 'Task not found.') {
+    return new DoclingTaskNotFoundError(taskId);
+  }
+  if (detail?.startsWith('Task result not found') === true) {
+    if (lastStatus?.task_status === 'failure') {
+      return new DoclingTaskError(lastStatus);
+    }
+    if (lastStatus?.task_status === 'success') {
+      return new DoclingResultExpiredError(taskId);
+    }
+    return new DoclingResultNotReadyError(taskId);
+  }
+  return new DoclingServiceError('Unexpected result lookup error', {
+    status: 404,
+    detail,
+    cause: error,
+  });
+}
+
+function shouldFallbackFromPresigned(error: unknown): boolean {
+  if (!(error instanceof DoclingHttpError) || ![400, 422].includes(error.status)) {
+    return false;
+  }
+  const detail = httpDetail(error.body)?.toLowerCase();
+  if (detail === undefined) {
+    return false;
+  }
+  if (detail.includes('artifact storage to be configured')) {
+    return true;
+  }
+  if (!detail.includes('presigned_url') && !detail.includes('presigned url')) {
+    return false;
+  }
+  return [
+    'input should be',
+    'unexpected value',
+    'validation error',
+    'literal_error',
+    'enum',
+  ].some(phrase => detail.includes(phrase));
+}
+
+function targetNeedsJson(target: SubmitTarget): target is InBodyTarget {
+  return target.kind === 'inbody';
+}
+
+function isPresignedTarget(target: BatchTarget): target is PresignedUrlTarget {
+  return target.kind === 'presigned_url';
+}
+
+function validateBatchRequest(request: BatchConvertSourcesRequest): void {
+  if (!Array.isArray(request.sources) || request.sources.length === 0) {
+    throw new DoclingProtocolError('Batch conversion requires at least one source');
+  }
+  for (const source of request.sources) {
+    if (source.kind === 'file') {
+      throw new DoclingProtocolError('Batch conversion does not accept file sources');
+    }
+    if (typeof source.kind !== 'string' || source.kind === '') {
+      throw new DoclingProtocolError('Batch source kind must not be empty');
+    }
+    validateKnownConnector(source, 'source');
+  }
+  if (
+    !isRecord(request.target) ||
+    typeof request.target.kind !== 'string' ||
+    request.target.kind === ''
+  ) {
+    throw new DoclingProtocolError('Batch target kind must not be empty');
+  }
+  if (['inbody', 'zip', 'put'].includes(request.target.kind)) {
+    throw new DoclingProtocolError(
+      `Batch conversion does not accept ${request.target.kind} targets`
+    );
+  }
+  validateKnownConnector(request.target, 'target');
+  validateCallbacks(request.callbacks);
+}
+
+function validateChunkRequestOptions(
+  request: ChunkSourcesRequest | ChunkSourceOptions
+): void {
+  if (
+    request.include_converted_doc !== undefined &&
+    typeof request.include_converted_doc !== 'boolean'
+  ) {
+    throw new DoclingProtocolError('include_converted_doc must be a boolean');
+  }
+  if (
+    request.target !== undefined &&
+    (!isRecord(request.target) || request.target.kind !== 'inbody')
+  ) {
+    throw new DoclingProtocolError('Chunk conversion only supports inbody targets');
+  }
+  const options = request.chunking_options;
+  if (options === undefined) {
+    return;
+  }
+  if (!isRecord(options)) {
+    throw new DoclingProtocolError('chunking_options must be an object');
+  }
+  for (const key of [
+    'use_markdown_tables',
+    'use_markdown_images',
+    'include_raw_text',
+    'merge_peers',
+  ]) {
+    const value = options[key];
+    if (value !== undefined && typeof value !== 'boolean') {
+      throw new DoclingProtocolError(`chunking_options.${key} must be a boolean`);
+    }
+  }
+  if (
+    options.image_placeholder !== undefined &&
+    typeof options.image_placeholder !== 'string'
+  ) {
+    throw new DoclingProtocolError(
+      'chunking_options.image_placeholder must be a string'
+    );
+  }
+  if (
+    options.max_tokens !== undefined &&
+    options.max_tokens !== null &&
+    !Number.isInteger(options.max_tokens)
+  ) {
+    throw new DoclingProtocolError(
+      'chunking_options.max_tokens must be an integer or null'
+    );
+  }
+  if (options.tokenizer !== undefined && typeof options.tokenizer !== 'string') {
+    throw new DoclingProtocolError('chunking_options.tokenizer must be a string');
+  }
+}
+
+function validateConversionSource(
+  source: ConversionSource | undefined
+): asserts source is ConversionSource {
+  if (source === undefined) {
+    throw new DoclingProtocolError('A conversion source is required');
+  }
+  if (source.kind === 'http') {
+    if (typeof source.url !== 'string' || source.url === '') {
+      throw new DoclingProtocolError('HTTP source url is required');
+    }
+    const url = parseHttpUrl(source.url, 'HTTP source');
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      throw new DoclingProtocolError('HTTP source must use HTTP or HTTPS');
+    }
+    if (url.pathname.toLowerCase().endsWith('.zip')) {
+      throw new DoclingProtocolError(
+        'ZIP URLs are not accepted on the Docling convert endpoint'
+      );
+    }
+    if (source.headers !== undefined && !isRecord(source.headers)) {
+      throw new DoclingProtocolError('HTTP source headers must be an object');
+    }
+    return;
+  }
+  if (
+    typeof source.filename !== 'string' ||
+    source.filename === '' ||
+    typeof source.base64_string !== 'string' ||
+    source.base64_string === ''
+  ) {
+    throw new DoclingProtocolError(
+      'File source filename and base64_string are required'
+    );
+  }
+}
+
+function validateSubmitTarget(target: SubmitTarget): void {
+  if (target.kind === 'put') {
+    parseHttpUrl(target.url, 'Put target');
+    return;
+  }
+  if (
+    ![
+      'inbody',
+      'zip',
+      'presigned_url',
+      's3',
+      'azure_blob',
+      'google_cloud_storage',
+      'google_drive',
+    ].includes(target.kind)
+  ) {
+    throw new DoclingProtocolError(
+      `Unsupported Docling conversion target: ${String(target.kind)}`
+    );
+  }
+  validateKnownConnector(target, 'target');
+}
+
+function validateKnownConnector(
+  value: { kind: string },
+  role: 'source' | 'target'
+): void {
+  const fields = value as unknown as Record<string, unknown>;
+  if (value.kind === 'http') {
+    requireStringFields(fields, ['url'], role, false);
+    parseHttpUrl(fields.url as string, `HTTP ${role}`);
+    return;
+  }
+  if (value.kind === 's3') {
+    requireStringFields(
+      fields,
+      ['endpoint', 'access_key', 'secret_key', 'bucket', 'key_prefix'],
+      role,
+      true
+    );
+    validateOptionalBoolean(fields.verify_ssl, `${role} verify_ssl`);
+    validatePositiveMaxElements(fields.max_num_elements, role);
+    return;
+  }
+  if (value.kind === 'azure_blob') {
+    requireStringFields(
+      fields,
+      ['account_name', 'container', 'connection_string', 'blob_prefix'],
+      role,
+      true
+    );
+    validateOptionalInteger(fields.max_num_elements, `${role} max_num_elements`);
+    return;
+  }
+  if (value.kind === 'google_cloud_storage') {
+    requireStringFields(fields, ['bucket', 'key_prefix'], role, true);
+    validatePositiveMaxElements(fields.max_num_elements, role);
+    validateOptionalString(fields.project, `${role} project`);
+    if (
+      fields.service_account_key !== undefined &&
+      fields.service_account_key !== null
+    ) {
+      if (!isRecord(fields.service_account_key)) {
+        throw new DoclingProtocolError(
+          `Google Cloud Storage ${role} service_account_key must be an object`
+        );
+      }
+      requireStringFields(
+        fields.service_account_key,
+        [
+          'project_id',
+          'private_key_id',
+          'private_key',
+          'client_email',
+          'client_id',
+          'auth_uri',
+          'token_uri',
+          'auth_provider_x509_cert_url',
+          'client_x509_cert_url',
+          'universe_domain',
+        ],
+        `${role} service_account_key`,
+        true
+      );
+    }
+    return;
+  }
+  if (value.kind === 'google_drive') {
+    requireStringFields(fields, ['path_id'], role);
+    if (
+      !hasNonEmptyString(fields.token_path) &&
+      !hasNonEmptyString(fields.refresh_token)
+    ) {
+      throw new DoclingProtocolError(
+        `Google Drive ${role} requires token_path or refresh_token`
+      );
+    }
+    if (!hasNonEmptyString(fields.credentials_path) && !isRecord(fields.credentials)) {
+      throw new DoclingProtocolError(
+        `Google Drive ${role} requires credentials_path or credentials`
+      );
+    }
+    validateOptionalString(fields.token_path, `${role} token_path`);
+    validateOptionalString(fields.refresh_token, `${role} refresh_token`);
+    validateOptionalString(fields.credentials_path, `${role} credentials_path`);
+    if (isRecord(fields.credentials)) {
+      requireStringFields(
+        fields.credentials,
+        [
+          'client_id',
+          'project_id',
+          'auth_uri',
+          'token_uri',
+          'auth_provider_x509_cert_url',
+          'client_secret',
+        ],
+        `${role} credentials`,
+        true
+      );
+      for (const key of ['auth_uri', 'token_uri', 'auth_provider_x509_cert_url']) {
+        parseHttpUrl(
+          fields.credentials[key] as string,
+          `Google Drive ${role} credentials.${key}`
+        );
+      }
+      const redirectUris = fields.credentials.redirect_uris;
+      if (
+        !Array.isArray(redirectUris) ||
+        redirectUris.some(uri => typeof uri !== 'string')
+      ) {
+        throw new DoclingProtocolError(
+          `Google Drive ${role} credentials redirect_uris must be an array of URLs`
+        );
+      }
+      for (const uri of redirectUris) {
+        parseHttpUrl(uri as string, `Google Drive ${role} redirect URI`);
+      }
+    }
+  }
+}
+
+function requireStringFields(
+  value: Record<string, unknown>,
+  fields: string[],
+  role: string,
+  allowMissingDefault = false
+): void {
+  for (const field of fields) {
+    if (
+      allowMissingDefault &&
+      ['key_prefix', 'blob_prefix'].includes(field) &&
+      value[field] === undefined
+    ) {
+      continue;
+    }
+    if (typeof value[field] !== 'string') {
+      throw new DoclingProtocolError(
+        `${value.kind as string} ${role} requires ${field}`
+      );
+    }
+  }
+}
+
+function validatePositiveMaxElements(value: unknown, role: string): void {
+  if (
+    value !== undefined &&
+    value !== null &&
+    (!Number.isSafeInteger(value) || (value as number) < 1)
+  ) {
+    throw new DoclingProtocolError(
+      `${role} max_num_elements must be a positive integer`
+    );
+  }
+}
+
+function validateOptionalInteger(value: unknown, name: string): void {
+  if (value !== undefined && value !== null && !Number.isSafeInteger(value)) {
+    throw new DoclingProtocolError(`${name} must be an integer or null`);
+  }
+}
+
+function validateOptionalBoolean(value: unknown, name: string): void {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new DoclingProtocolError(`${name} must be a boolean`);
+  }
+}
+
+function validateOptionalString(value: unknown, name: string): void {
+  if (value !== undefined && value !== null && typeof value !== 'string') {
+    throw new DoclingProtocolError(`${name} must be a string or null`);
+  }
+}
+
+function validateCallbacks(callbacks: CallbackSpec[] | undefined): void {
+  if (callbacks !== undefined && !Array.isArray(callbacks)) {
+    throw new DoclingProtocolError('callbacks must be an array');
+  }
+  for (const callback of callbacks ?? []) {
+    if (!isRecord(callback) || typeof callback.url !== 'string') {
+      throw new DoclingProtocolError('Callback url is required');
+    }
+    parseAbsoluteUrl(callback.url, 'Callback url');
+    if (
+      callback.headers !== undefined &&
+      (!isRecord(callback.headers) ||
+        Object.values(callback.headers).some(value => typeof value !== 'string'))
+    ) {
+      throw new DoclingProtocolError('Callback headers must contain string values');
+    }
+    if (callback.ca_cert !== undefined && typeof callback.ca_cert !== 'string') {
+      throw new DoclingProtocolError('Callback ca_cert must be a string');
+    }
+  }
+}
+
+function parseHttpUrl(value: unknown, name: string): URL {
+  const url = parseAbsoluteUrl(value, name);
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new DoclingProtocolError(`${name} must use HTTP or HTTPS`);
+  }
+  return url;
+}
+
+function parseAbsoluteUrl(value: unknown, name: string): URL {
+  if (typeof value !== 'string' || value === '') {
+    throw new DoclingProtocolError(`${name} must be a URL`);
+  }
+  try {
+    return new URL(value);
+  } catch (error) {
+    throw new DoclingProtocolError(`${name} must be a valid URL`, {
+      cause: error,
+    });
+  }
+}
+
+async function fileSourceFromBlob(
+  source: Extract<NormalizedSource, { kind: 'multipart' }>,
+  signal?: AbortSignal
+): Promise<FileSource> {
+  throwIfAborted(signal);
+  const bytes = new Uint8Array(await source.blob.arrayBuffer());
+  throwIfAborted(signal);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  const base64 =
+    typeof globalThis.btoa === 'function'
+      ? globalThis.btoa(binary)
+      : Buffer.from(bytes).toString('base64');
+  return {
+    kind: 'file',
+    filename: source.descriptor.filename,
+    base64_string: base64,
+  };
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) {
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new DOMException('The operation was aborted', 'AbortError');
+  }
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value !== '';
+}
+
+function filenameFromContentDisposition(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  const encoded = /filename\*=UTF-8''([^;]+)/i.exec(value)?.[1];
+  if (encoded !== undefined) {
+    try {
+      return decodeURIComponent(encoded.replace(/^"|"$/g, ''));
+    } catch {
+      return encoded;
+    }
+  }
+  return /filename="?([^";]+)"?/i.exec(value)?.[1] ?? null;
+}
+
+function httpDetail(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.detail === 'string' ? value.detail : undefined;
+}
+
+function normalizeBaseUrl(value: string): string {
+  const normalized = value.trim().replace(/\/+$/, '');
+  if (normalized === '') {
+    throw new DoclingProtocolError('Docling baseUrl must not be empty');
+  }
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch (error) {
+    throw new DoclingProtocolError('Docling baseUrl must be a valid URL', {
+      cause: error,
+    });
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new DoclingProtocolError('Docling baseUrl must use HTTP or HTTPS');
+  }
+  if (url.search !== '' || url.hash !== '') {
+    throw new DoclingProtocolError(
+      'Docling baseUrl must not include query or fragment components'
+    );
+  }
+  const path = url.pathname.replace(/\/+$/, '');
+  if (path.endsWith('/v1')) {
+    throw new DoclingProtocolError(
+      'Docling baseUrl must be the service base URL and not include /v1'
+    );
+  }
+  url.pathname = path;
+  return url.toString().replace(/\/+$/, '');
+}
+
+function normalizeHeaders(
+  headers: Record<string, string> | undefined
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers ?? {}).map(([name, value]) => [name.toLowerCase(), value])
+  );
+}
+
+function positiveNumber(value: number, name: string): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new DoclingProtocolError(`${name} must be a positive number`);
+  }
+  return value;
+}
+
+function nonNegativeNumber(value: number, name: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new DoclingProtocolError(`${name} must be non-negative`);
+  }
+  return value;
+}
+
+function requireTaskId(taskId: string): void {
+  if (taskId === '') {
+    throw new DoclingProtocolError('taskId must not be empty');
+  }
+}
+
+function isChunkSourcesRequest(value: unknown): value is ChunkSourcesRequest {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.sources) &&
+    ['hybrid', 'hierarchical'].includes(String(value.chunker))
+  );
+}
+
+function fallbackInput(source: ConversionSourceInput): ConversionInput {
+  if (typeof source === 'string') {
+    return {
+      filename: source.replaceAll('\\', '/').split('/').at(-1) || 'document',
+      source,
+    };
+  }
+  if (source instanceof URL) {
+    return {
+      filename: source.pathname.split('/').filter(Boolean).at(-1) ?? 'document',
+      source: source.toString(),
+    };
+  }
+  if (isRecord(source)) {
+    let urlFilename: string | undefined;
+    if (typeof source.url === 'string') {
+      try {
+        urlFilename =
+          new URL(source.url).pathname.split('/').filter(Boolean).at(-1) ?? 'document';
+      } catch {
+        urlFilename = source.url.replaceAll('\\', '/').split('/').at(-1);
+      }
+    }
+    const filename =
+      typeof source.filename === 'string'
+        ? source.filename
+        : typeof source.url === 'string'
+          ? urlFilename || 'document'
+          : 'document';
+    return { filename, source: filename };
+  }
+  return { filename: 'document', source: 'document' };
+}
+
+function isAbortError(value: unknown): boolean {
+  return value instanceof Error && value.name === 'AbortError';
+}
+
+async function* mapSourcesToItems(
+  sources: Iterable<ConversionSourceInput> | AsyncIterable<ConversionSourceInput>,
+  options?: ConvertDocumentsOptions,
+  headers?: Record<string, string>
+): AsyncGenerator<ConversionItem> {
+  if (Symbol.asyncIterator in Object(sources)) {
+    for await (const source of sources as AsyncIterable<ConversionSourceInput>) {
+      yield { source, options, headers };
+    }
+    return;
+  }
+  for (const source of sources as Iterable<ConversionSourceInput>) {
+    yield { source, options, headers };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/docling-client/src/errors.ts
+++ b/docling-client/src/errors.ts
@@ -1,0 +1,158 @@
+import type { PublicFailureInfo, TaskStatusResponse } from './types';
+
+export class DoclingError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = new.target.name;
+  }
+}
+
+export class DoclingServiceError extends DoclingError {
+  readonly status: number | null;
+  readonly detail: string | null;
+
+  constructor(
+    message: string,
+    options: { status?: number; detail?: string; cause?: unknown } = {}
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.status = options.status ?? null;
+    this.detail = options.detail ?? null;
+  }
+}
+
+export class DoclingHttpError extends DoclingServiceError {
+  readonly method: string;
+  readonly url: string;
+  readonly status: number;
+  readonly body: unknown;
+  readonly headers: Readonly<Record<string, string>>;
+
+  constructor(options: {
+    method: string;
+    url: string;
+    status: number;
+    body: unknown;
+    headers?: Readonly<Record<string, string>>;
+    detail?: string;
+  }) {
+    const serialized =
+      typeof options.body === 'string' ? options.body : safeSerialize(options.body);
+    super(
+      `Docling request ${options.method} ${options.url} returned HTTP ${options.status}${
+        serialized === '' ? '' : `: ${serialized.slice(0, 500)}`
+      }`,
+      { status: options.status, detail: options.detail }
+    );
+    this.method = options.method;
+    this.url = options.url;
+    this.status = options.status;
+    this.body = options.body;
+    this.headers = options.headers ?? {};
+  }
+}
+
+function safeSerialize(value: unknown): string {
+  if (value === undefined) {
+    return '';
+  }
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return String(value);
+  }
+}
+
+export class DoclingProtocolError extends DoclingError {}
+
+export class DoclingResponseSchemaMismatchError extends DoclingServiceError {}
+
+export class DoclingServiceUnavailableError extends DoclingServiceError {}
+
+export class DoclingUsageLimitExceededError extends DoclingHttpError {
+  readonly currentUsage: number | null;
+  readonly limit: number | null;
+
+  constructor(options: {
+    method: string;
+    url: string;
+    status: number;
+    body: unknown;
+    headers?: Readonly<Record<string, string>>;
+    currentUsage?: number;
+    limit?: number;
+    detail?: string;
+  }) {
+    super(options);
+    this.currentUsage = options.currentUsage ?? null;
+    this.limit = options.limit ?? null;
+  }
+}
+
+export class DoclingTaskError extends DoclingError {
+  readonly task: TaskStatusResponse;
+  readonly failure?: PublicFailureInfo;
+
+  constructor(task: TaskStatusResponse) {
+    super(
+      task.failure?.message ??
+        task.error_message ??
+        `Docling task ${task.task_id} failed`
+    );
+    this.task = task;
+    if (task.failure !== undefined && task.failure !== null) {
+      this.failure = task.failure;
+    }
+  }
+}
+
+export class DoclingTimeoutError extends DoclingError {
+  readonly taskId: string;
+  readonly timeoutMs: number;
+
+  constructor(taskId: string, timeoutMs: number) {
+    super(`Docling task ${taskId} did not finish within ${timeoutMs} ms`);
+    this.taskId = taskId;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export class DoclingTaskNotFoundError extends DoclingError {
+  readonly taskId: string;
+
+  constructor(taskId: string) {
+    super(`Docling task ${taskId} was not found`);
+    this.taskId = taskId;
+  }
+}
+
+export class DoclingResultNotReadyError extends DoclingError {
+  readonly taskId: string;
+
+  constructor(taskId: string) {
+    super(`Result for Docling task ${taskId} is not ready`);
+    this.taskId = taskId;
+  }
+}
+
+export class DoclingResultExpiredError extends DoclingError {
+  readonly taskId: string;
+
+  constructor(taskId: string) {
+    super(`Result for Docling task ${taskId} has expired`);
+    this.taskId = taskId;
+  }
+}
+
+export class DoclingArtifactDownloadError extends DoclingError {}
+
+export class DoclingConversionError extends DoclingError {}
+
+export class DoclingBatchConversionError extends DoclingError {
+  readonly failures: Error[];
+
+  constructor(message: string, failures: Error[]) {
+    super(`${message} (${failures.length} failure(s))`);
+    this.failures = failures;
+  }
+}

--- a/docling-client/src/index.ts
+++ b/docling-client/src/index.ts
@@ -1,0 +1,7 @@
+export * from './artifacts';
+export * from './client';
+export * from './errors';
+export * from './sources';
+export * from './transport';
+export * from './types';
+export * from './watchers';

--- a/docling-client/src/scheduler.ts
+++ b/docling-client/src/scheduler.ts
@@ -1,0 +1,150 @@
+import { DoclingProtocolError } from './errors';
+
+export interface BoundedMapOptions {
+  maxInFlight: number;
+  ordered: boolean;
+  signal?: AbortSignal;
+}
+
+interface Completed<TItem, TResult> {
+  index: number;
+  item: TItem;
+  outcome: TResult | Error;
+}
+
+export async function* boundedOutcomes<TItem, TResult>(
+  items: Iterable<TItem> | AsyncIterable<TItem>,
+  process: (item: TItem, index: number, signal: AbortSignal) => Promise<TResult>,
+  options: BoundedMapOptions
+): AsyncGenerator<Completed<TItem, TResult>> {
+  validateConcurrency(options.maxInFlight);
+  const iterator = toAsyncIterator(items);
+  const controller = new AbortController();
+  const signal = combineAbortSignals(options.signal, controller.signal);
+  if (signal.aborted) {
+    throw abortReason(signal);
+  }
+  const active = new Map<number, Promise<Completed<TItem, TResult>>>();
+  const buffered = new Map<number, Completed<TItem, TResult>>();
+  let nextInputIndex = 0;
+  let nextOutputIndex = 0;
+  let exhausted = false;
+
+  const startNext = async (): Promise<void> => {
+    if (exhausted || signal.aborted) {
+      return;
+    }
+    const next = await iterator.next();
+    if (next.done === true) {
+      exhausted = true;
+      return;
+    }
+    const index = nextInputIndex;
+    nextInputIndex += 1;
+    const item = next.value;
+    const operation = process(item, index, signal)
+      .then(outcome => ({ index, item, outcome }))
+      .catch((error: unknown) => {
+        if (signal.aborted) {
+          throw abortReason(signal);
+        }
+        return {
+          index,
+          item,
+          outcome: normalizeError(error),
+        };
+      });
+    active.set(index, operation);
+  };
+
+  try {
+    while (active.size < options.maxInFlight && !exhausted) {
+      await startNext();
+    }
+
+    while (active.size > 0) {
+      const completed = await Promise.race(active.values());
+      active.delete(completed.index);
+      await startNext();
+
+      if (!options.ordered) {
+        yield completed;
+        continue;
+      }
+      buffered.set(completed.index, completed);
+      while (buffered.has(nextOutputIndex)) {
+        const ready = buffered.get(nextOutputIndex);
+        buffered.delete(nextOutputIndex);
+        nextOutputIndex += 1;
+        if (ready !== undefined) {
+          yield ready;
+        }
+      }
+    }
+  } finally {
+    controller.abort(new Error('Docling bounded operation stopped'));
+    await Promise.allSettled(active.values());
+    await iterator.return?.();
+  }
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException('The operation was aborted', 'AbortError');
+}
+
+export function validateConcurrency(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > 512) {
+    throw new DoclingProtocolError(
+      'Concurrency must be a safe integer between 1 and 512'
+    );
+  }
+  return value;
+}
+
+function toAsyncIterator<T>(items: Iterable<T> | AsyncIterable<T>): AsyncIterator<T> {
+  if (Symbol.asyncIterator in Object(items)) {
+    return (items as AsyncIterable<T>)[Symbol.asyncIterator]();
+  }
+  const iterator = (items as Iterable<T>)[Symbol.iterator]();
+  return {
+    next: async () => iterator.next(),
+    return:
+      iterator.return === undefined
+        ? undefined
+        : async () => {
+            const returned = iterator.return?.();
+            return returned ?? { done: true, value: undefined };
+          },
+  };
+}
+
+function normalizeError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+function combineAbortSignals(
+  callerSignal: AbortSignal | undefined,
+  internalSignal: AbortSignal
+): AbortSignal {
+  if (callerSignal === undefined) {
+    return internalSignal;
+  }
+  if (typeof AbortSignal.any === 'function') {
+    return AbortSignal.any([callerSignal, internalSignal]);
+  }
+  const controller = new AbortController();
+  const abort = (signal: AbortSignal) => controller.abort(signal.reason);
+  if (callerSignal.aborted) {
+    abort(callerSignal);
+  } else {
+    callerSignal.addEventListener('abort', () => abort(callerSignal), {
+      once: true,
+    });
+  }
+  internalSignal.addEventListener('abort', () => abort(internalSignal), {
+    once: true,
+  });
+  return controller.signal;
+}

--- a/docling-client/src/sources.ts
+++ b/docling-client/src/sources.ts
@@ -1,0 +1,1045 @@
+import { DoclingProtocolError } from './errors';
+import type {
+  BinaryFileSource,
+  ConversionInput,
+  ConversionSource,
+  ConversionSourceInput,
+  ConvertDocumentsOptions,
+  FileSource,
+  HttpSource,
+  InputFormat,
+} from './types';
+
+export interface NormalizedJsonSource {
+  kind: 'json';
+  source: ConversionSource;
+  descriptor: ConversionInput;
+}
+
+export interface NormalizedMultipartSource {
+  kind: 'multipart';
+  blob: Blob;
+  descriptor: ConversionInput;
+}
+
+export type NormalizedSource = NormalizedJsonSource | NormalizedMultipartSource;
+
+const EXTENSION_FORMATS: Readonly<Record<string, InputFormat>> = {
+  pdf: 'pdf',
+  docx: 'docx',
+  dotx: 'docx',
+  docm: 'docx',
+  dotm: 'docx',
+  doc: 'doc',
+  dot: 'doc',
+  pptx: 'pptx',
+  potx: 'pptx',
+  ppsx: 'pptx',
+  pptm: 'pptx',
+  potm: 'pptx',
+  ppsm: 'pptx',
+  ppt: 'ppt',
+  pot: 'ppt',
+  pps: 'ppt',
+  html: 'html',
+  htm: 'html',
+  xhtml: 'html',
+  md: 'md',
+  markdown: 'md',
+  txt: 'md',
+  text: 'md',
+  qmd: 'md',
+  rmd: 'md',
+  csv: 'csv',
+  xlsx: 'xlsx',
+  xlsm: 'xlsx',
+  xls: 'xls',
+  xlt: 'xls',
+  asciidoc: 'asciidoc',
+  adoc: 'asciidoc',
+  asc: 'asciidoc',
+  json: 'json_docling',
+  dclx: 'dclx',
+  'dclg.xml': 'xml_doclang',
+  dclg: 'xml_doclang',
+  xml: 'xml_jats',
+  nxml: 'xml_jats',
+  xbrl: 'xml_xbrl',
+  'tar.gz': 'mets_gbs',
+  jpg: 'image',
+  jpeg: 'image',
+  png: 'image',
+  tif: 'image',
+  tiff: 'image',
+  bmp: 'image',
+  webp: 'image',
+  wav: 'audio',
+  mp3: 'audio',
+  m4a: 'audio',
+  aac: 'audio',
+  ogg: 'audio',
+  flac: 'audio',
+  mp4: 'video',
+  avi: 'video',
+  mov: 'video',
+  mkv: 'video',
+  webm: 'video',
+  vtt: 'vtt',
+  odt: 'odt',
+  ott: 'odt',
+  ods: 'ods',
+  ots: 'ods',
+  odp: 'odp',
+  otp: 'odp',
+  tex: 'latex',
+  latex: 'latex',
+  eml: 'email',
+  epub: 'epub',
+  boxnote: 'boxnote',
+};
+
+export async function normalizeSourceInput(
+  input: ConversionSourceInput,
+  signal?: AbortSignal
+): Promise<NormalizedSource> {
+  throwIfAborted(signal);
+  if (typeof input === 'string') {
+    return normalizeStringSource(input, signal);
+  }
+  if (input instanceof URL) {
+    return normalizeHttpUrl(input.toString());
+  }
+  if (isHttpSource(input)) {
+    validateHttpUrl(input.url, true);
+    const normalized: NormalizedJsonSource = {
+      kind: 'json',
+      source: clone(input),
+      descriptor: describeHttpSource(input.url),
+    };
+    throwIfAborted(signal);
+    return normalized;
+  }
+  if (isFileSource(input)) {
+    const normalized: NormalizedJsonSource = {
+      kind: 'json',
+      source: clone(input),
+      descriptor: {
+        filename: input.filename,
+        source: input.filename,
+        format: guessInputFormat(input.filename),
+        file_size: base64ByteLength(input.base64_string),
+      },
+    };
+    throwIfAborted(signal);
+    return normalized;
+  }
+  if (isBinaryFileSource(input)) {
+    const blob = await toBlob(input.data, input.contentType);
+    throwIfAborted(signal);
+    return {
+      kind: 'multipart',
+      blob,
+      descriptor: {
+        filename: input.filename,
+        source: input.filename,
+        format: guessInputFormat(input.filename),
+        file_size: blob.size,
+      },
+    };
+  }
+  throw new DoclingProtocolError('Unsupported Docling conversion source');
+}
+
+export function resolveConvertOptions(
+  defaults: ConvertDocumentsOptions,
+  overrides: ConvertDocumentsOptions | undefined
+): ConvertDocumentsOptions {
+  const resolved = clone(defaults);
+  for (const [key, value] of Object.entries(overrides ?? {})) {
+    if (value === undefined) {
+      continue;
+    }
+    if (value === null) {
+      delete resolved[key];
+      continue;
+    }
+    resolved[key] = clone(value);
+  }
+  decodeNestedConfigStrings(resolved);
+  validateConvertOptions(resolved);
+  return resolved;
+}
+
+function decodeNestedConfigStrings(options: ConvertDocumentsOptions): void {
+  for (const key of JSON_STRING_CONFIG_OPTIONS) {
+    const value = options[key];
+    if (typeof value !== 'string') {
+      continue;
+    }
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(value) as unknown;
+    } catch (error) {
+      throw new DoclingProtocolError(`${key} contains invalid JSON`, {
+        cause: error,
+      });
+    }
+    if (decoded === null || typeof decoded !== 'object' || Array.isArray(decoded)) {
+      throw new DoclingProtocolError(`${key} JSON must decode to an object`);
+    }
+    options[key] = decoded as Record<string, unknown>;
+  }
+}
+
+export function withJsonOutput(
+  options: ConvertDocumentsOptions
+): ConvertDocumentsOptions {
+  const formats = options.to_formats ?? ['md'];
+  if (formats.includes('json')) {
+    return clone(options);
+  }
+  return {
+    ...clone(options),
+    to_formats: [...formats, 'json'],
+  };
+}
+
+export function validateConvertOptions(options: ConvertDocumentsOptions): void {
+  validateStringEnumArray(options.from_formats, INPUT_FORMATS, 'from_formats');
+  validateStringEnumArray(options.to_formats, OUTPUT_FORMATS, 'to_formats');
+  validateStringEnum(options.pipeline, PIPELINES, 'pipeline');
+  validateStringEnum(
+    options.image_export_mode,
+    IMAGE_EXPORT_MODES,
+    'image_export_mode'
+  );
+  validateStringEnum(options.table_mode, TABLE_MODES, 'table_mode');
+  validateStringEnum(options.pdf_backend, PDF_BACKENDS, 'pdf_backend');
+  if (options.vlm_pipeline_model !== undefined && options.vlm_pipeline_model !== null) {
+    validateStringEnum(
+      options.vlm_pipeline_model,
+      LEGACY_VLM_MODELS,
+      'vlm_pipeline_model'
+    );
+  }
+  if (options.page_range !== undefined) {
+    validatePageRange(options.page_range);
+  }
+
+  for (const key of BOOLEAN_OPTIONS) {
+    const value = options[key];
+    if (value !== undefined && typeof value !== 'boolean') {
+      throw new DoclingProtocolError(`${key} must be a boolean`);
+    }
+  }
+  for (const key of NUMBER_OPTIONS) {
+    const value = options[key];
+    if (
+      value !== undefined &&
+      value !== null &&
+      (typeof value !== 'number' || !Number.isFinite(value))
+    ) {
+      throw new DoclingProtocolError(`${key} must be a finite number or null`);
+    }
+  }
+  for (const key of STRING_OPTIONS) {
+    const value = options[key];
+    if (value !== undefined && value !== null && typeof value !== 'string') {
+      throw new DoclingProtocolError(`${key} must be a string or null`);
+    }
+  }
+  if (
+    options.ocr_lang !== undefined &&
+    options.ocr_lang !== null &&
+    (!Array.isArray(options.ocr_lang) ||
+      options.ocr_lang.some(value => typeof value !== 'string'))
+  ) {
+    throw new DoclingProtocolError('ocr_lang must be an array of strings or null');
+  }
+  for (const key of RECORD_OPTIONS) {
+    const value = options[key];
+    if (
+      value !== undefined &&
+      value !== null &&
+      (typeof value !== 'object' || Array.isArray(value))
+    ) {
+      throw new DoclingProtocolError(`${key} must be an object or null`);
+    }
+  }
+  validateLegacyPictureDescription(options.picture_description_local);
+  validateLegacyPictureDescription(options.picture_description_api, true);
+  validateLegacyVlmModel(options.vlm_pipeline_model_local);
+  validateLegacyVlmModel(options.vlm_pipeline_model_api, true);
+  validateOptionExclusivity(options);
+}
+
+function validateLegacyPictureDescription(value: unknown, api = false): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    throw new DoclingProtocolError(
+      `${api ? 'picture_description_api' : 'picture_description_local'} must be an object`
+    );
+  }
+  const path = api ? 'picture_description_api' : 'picture_description_local';
+  if (api) {
+    validateAbsoluteUrl(value.url, `${path}.url`);
+    validateOptionalStringRecord(value.headers, `${path}.headers`);
+    validateOptionalRecord(value.params, `${path}.params`);
+    validateOptionalPositiveInteger(value.concurrency, `${path}.concurrency`);
+    validateOptionalFiniteNumber(value.timeout, `${path}.timeout`);
+  } else {
+    validateRequiredString(value.repo_id, `${path}.repo_id`);
+    validateOptionalRecord(value.generation_config, `${path}.generation_config`);
+  }
+  validateOptionalString(value.prompt, `${path}.prompt`);
+  validateOptionalEnumArray(
+    value.classification_allow,
+    PICTURE_CLASSIFICATION_LABELS,
+    `${path}.classification_allow`
+  );
+  validateOptionalEnumArray(
+    value.classification_deny,
+    PICTURE_CLASSIFICATION_LABELS,
+    `${path}.classification_deny`
+  );
+  const minimum = value.classification_min_confidence;
+  if (
+    minimum !== undefined &&
+    (typeof minimum !== 'number' ||
+      !Number.isFinite(minimum) ||
+      minimum < 0 ||
+      minimum > 1)
+  ) {
+    throw new DoclingProtocolError(
+      `${path}.classification_min_confidence must be between 0 and 1`
+    );
+  }
+}
+
+function validateLegacyVlmModel(value: unknown, api = false): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    throw new DoclingProtocolError(
+      `${api ? 'vlm_pipeline_model_api' : 'vlm_pipeline_model_local'} must be an object`
+    );
+  }
+  const path = api ? 'vlm_pipeline_model_api' : 'vlm_pipeline_model_local';
+  if (api) {
+    validateAbsoluteUrl(value.url, `${path}.url`);
+    validateOptionalStringRecord(value.headers, `${path}.headers`);
+    validateOptionalRecord(value.params, `${path}.params`);
+    validateOptionalPositiveInteger(value.concurrency, `${path}.concurrency`);
+    validateOptionalFiniteNumber(value.timeout, `${path}.timeout`);
+  } else {
+    validateRequiredString(value.repo_id, `${path}.repo_id`);
+    validateRequiredEnum(
+      value.inference_framework,
+      VLM_INFERENCE_FRAMEWORKS,
+      `${path}.inference_framework`
+    );
+    validateStringEnum(
+      value.transformers_model_type as string | undefined,
+      TRANSFORMERS_MODEL_TYPES,
+      `${path}.transformers_model_type`
+    );
+    validateOptionalRecord(
+      value.extra_generation_config,
+      `${path}.extra_generation_config`
+    );
+  }
+  validateRequiredEnum(
+    value.response_format,
+    VLM_RESPONSE_FORMATS,
+    `${path}.response_format`
+  );
+  validateOptionalString(value.prompt, `${path}.prompt`);
+  validateOptionalFiniteNumber(value.scale, `${path}.scale`);
+  validateOptionalFiniteNumber(value.temperature, `${path}.temperature`);
+}
+
+function validateOptionExclusivity(options: ConvertDocumentsOptions): void {
+  const present = (...values: unknown[]) =>
+    values.filter(value => value !== undefined && value !== null).length;
+  const conflicting = (preset: unknown, custom: unknown) =>
+    typeof preset === 'string' &&
+    preset !== '' &&
+    isRecord(custom) &&
+    Object.keys(custom).length > 0;
+
+  if (present(options.picture_description_local, options.picture_description_api) > 1) {
+    throw new DoclingProtocolError(
+      'picture_description_local and picture_description_api are mutually exclusive'
+    );
+  }
+  const legacyVlmCount = present(
+    options.vlm_pipeline_model,
+    options.vlm_pipeline_model_local,
+    options.vlm_pipeline_model_api
+  );
+  if (legacyVlmCount > 1) {
+    throw new DoclingProtocolError(
+      'vlm_pipeline_model, vlm_pipeline_model_local, and vlm_pipeline_model_api are mutually exclusive'
+    );
+  }
+  if (conflicting(options.vlm_pipeline_preset, options.vlm_pipeline_custom_config)) {
+    throw new DoclingProtocolError(
+      'vlm_pipeline_preset and vlm_pipeline_custom_config are mutually exclusive'
+    );
+  }
+  if (
+    legacyVlmCount > 0 &&
+    present(options.vlm_pipeline_preset, options.vlm_pipeline_custom_config) > 0
+  ) {
+    throw new DoclingProtocolError(
+      'Legacy VLM model options cannot be mixed with VLM preset/custom options'
+    );
+  }
+  const legacyPictureCount = present(
+    options.picture_description_local,
+    options.picture_description_api
+  );
+  if (
+    conflicting(
+      options.picture_description_preset,
+      options.picture_description_custom_config
+    )
+  ) {
+    throw new DoclingProtocolError(
+      'picture_description_preset and picture_description_custom_config are mutually exclusive'
+    );
+  }
+  if (
+    legacyPictureCount > 0 &&
+    present(
+      options.picture_description_preset,
+      options.picture_description_custom_config
+    ) > 0
+  ) {
+    throw new DoclingProtocolError(
+      'Legacy picture-description options cannot be mixed with picture-description preset/custom options'
+    );
+  }
+  for (const [name, preset, custom] of [
+    ['code_formula', options.code_formula_preset, options.code_formula_custom_config],
+    ['layout', options.layout_preset, options.layout_custom_config],
+    [
+      'picture_classification',
+      options.picture_classification_preset,
+      options.picture_classification_custom_config,
+    ],
+  ] as const) {
+    if (conflicting(preset, custom)) {
+      throw new DoclingProtocolError(
+        `${name}_preset and ${name}_custom_config are mutually exclusive`
+      );
+    }
+  }
+  if (
+    options.ocr_preset !== undefined &&
+    options.ocr_preset !== 'auto' &&
+    isRecord(options.ocr_custom_config) &&
+    Object.keys(options.ocr_custom_config).length > 0
+  ) {
+    throw new DoclingProtocolError(
+      'ocr_preset and ocr_custom_config are mutually exclusive'
+    );
+  }
+}
+
+export function applyPageLimits(
+  options: ConvertDocumentsOptions,
+  pageRange?: [number, number],
+  maxNumPages?: number
+): ConvertDocumentsOptions {
+  let effectiveRange = pageRange ?? options.page_range;
+  if (maxNumPages !== undefined) {
+    validateNonNegativeSafeInteger(maxNumPages, 'maxNumPages');
+    effectiveRange = [
+      effectiveRange?.[0] ?? 1,
+      Math.min(effectiveRange?.[1] ?? Number.MAX_SAFE_INTEGER, maxNumPages),
+    ];
+  }
+  if (effectiveRange !== undefined) {
+    validatePageRange(effectiveRange);
+    return { ...clone(options), page_range: [...effectiveRange] };
+  }
+  return clone(options);
+}
+
+export function validateMaxFileSize(value: number | undefined): void {
+  if (value === undefined) {
+    return;
+  }
+  validateNonNegativeSafeInteger(value, 'maxFileSize');
+}
+
+export function preflightFileSize(
+  source: NormalizedSource,
+  maxFileSize: number | undefined
+): string | null {
+  if (
+    maxFileSize === undefined ||
+    source.descriptor.file_size === undefined ||
+    source.descriptor.file_size === null ||
+    source.descriptor.file_size <= maxFileSize
+  ) {
+    return null;
+  }
+  return `File size ${source.descriptor.file_size} exceeds the configured limit of ${maxFileSize} bytes`;
+}
+
+export function formValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+export async function fileSourceFromBinary(
+  source: BinaryFileSource,
+  signal?: AbortSignal
+): Promise<FileSource> {
+  throwIfAborted(signal);
+  const bytes = new Uint8Array(await (await toBlob(source.data)).arrayBuffer());
+  throwIfAborted(signal);
+  return {
+    kind: 'file',
+    filename: source.filename,
+    base64_string: bytesToBase64(bytes),
+  };
+}
+
+async function normalizeStringSource(
+  value: string,
+  signal?: AbortSignal
+): Promise<NormalizedSource> {
+  const scheme = /^([a-z][a-z\d+.-]*):\/\//i.exec(value)?.[1]?.toLowerCase();
+  if (scheme !== undefined) {
+    if (!['http', 'https'].includes(scheme)) {
+      throw new DoclingProtocolError(
+        `Unsupported document source URL scheme: ${scheme}`
+      );
+    }
+    return normalizeHttpUrl(value);
+  }
+
+  let bytes: Uint8Array;
+  try {
+    const { readFile } = await import('node:fs/promises');
+    bytes = await readFile(value, { signal });
+  } catch (error) {
+    if (signal?.aborted === true) {
+      throw abortReason(signal);
+    }
+    throw new DoclingProtocolError(`Could not read local document: ${value}`, {
+      cause: error,
+    });
+  }
+  throwIfAborted(signal);
+  const filename = fileNameFromPath(value);
+  const blob = new Blob([Uint8Array.from(bytes).buffer], {
+    type: guessMimeType(filename),
+  });
+  return {
+    kind: 'multipart',
+    blob,
+    descriptor: {
+      filename,
+      source: value,
+      format: guessInputFormat(filename),
+      file_size: bytes.byteLength,
+    },
+  };
+}
+
+function normalizeHttpUrl(value: string): NormalizedJsonSource {
+  validateHttpUrl(value, true);
+  const source: HttpSource = { kind: 'http', url: value, headers: {} };
+  return {
+    kind: 'json',
+    source,
+    descriptor: describeHttpSource(value),
+  };
+}
+
+function validateHttpUrl(value: string, rejectZip: boolean): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new DoclingProtocolError('Document source must be a valid URL', {
+      cause: error,
+    });
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new DoclingProtocolError(
+      `Unsupported document source URL scheme: ${url.protocol.replace(':', '')}`
+    );
+  }
+  if (rejectZip && url.pathname.toLowerCase().endsWith('.zip')) {
+    throw new DoclingProtocolError(
+      'ZIP URLs are not accepted on the Docling convert endpoint'
+    );
+  }
+  return url;
+}
+
+function describeHttpSource(value: string): ConversionInput {
+  const url = validateHttpUrl(value, true);
+  const pathParts = url.pathname.split('/').filter(part => part !== '');
+  const filename = pathParts.at(-1) ?? 'document';
+  return {
+    filename,
+    source: value,
+    format: guessInputFormat(filename),
+    file_size: null,
+  };
+}
+
+function guessInputFormat(filename: string): InputFormat {
+  const normalized = filename.toLowerCase();
+  const extension =
+    ['dclg.xml', 'tar.gz'].find(suffix => normalized.endsWith(`.${suffix}`)) ??
+    normalized.split('.').at(-1) ??
+    '';
+  return EXTENSION_FORMATS[extension] ?? 'pdf';
+}
+
+function guessMimeType(filename: string): string {
+  const extension = filename.toLowerCase().split('.').at(-1) ?? '';
+  return (
+    {
+      pdf: 'application/pdf',
+      doc: 'application/msword',
+      docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      ppt: 'application/vnd.ms-powerpoint',
+      pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      xls: 'application/vnd.ms-excel',
+      xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      html: 'text/html',
+      htm: 'text/html',
+      md: 'text/markdown',
+      txt: 'text/plain',
+      csv: 'text/csv',
+      json: 'application/json',
+      png: 'image/png',
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      tif: 'image/tiff',
+      tiff: 'image/tiff',
+      wav: 'audio/wav',
+      mp3: 'audio/mpeg',
+      mp4: 'video/mp4',
+      vtt: 'text/vtt',
+      eml: 'message/rfc822',
+      epub: 'application/epub+zip',
+    }[extension] ?? 'application/octet-stream'
+  );
+}
+
+const INPUT_FORMATS = new Set<InputFormat>([
+  'docx',
+  'doc',
+  'pptx',
+  'html',
+  'image',
+  'pdf',
+  'asciidoc',
+  'md',
+  'csv',
+  'xlsx',
+  'xml_uspto',
+  'xml_jats',
+  'json_docling',
+  'dclx',
+  'audio',
+  'vtt',
+  'xml_xbrl',
+  'mets_gbs',
+  'latex',
+  'ppt',
+  'xls',
+  'odt',
+  'ods',
+  'odp',
+  'xml_doclang',
+  'video',
+  'email',
+  'epub',
+  'boxnote',
+]);
+const OUTPUT_FORMATS = new Set([
+  'md',
+  'json',
+  'yaml',
+  'html',
+  'html_split_page',
+  'text',
+  'doctags',
+  'vtt',
+  'doclang',
+  'dclx',
+  'chunks',
+]);
+const PIPELINES = new Set(['legacy', 'standard', 'vlm', 'asr']);
+const IMAGE_EXPORT_MODES = new Set(['placeholder', 'embedded', 'referenced']);
+const TABLE_MODES = new Set(['fast', 'accurate']);
+const PDF_BACKENDS = new Set([
+  'pypdfium2',
+  'docling_parse',
+  'threaded_docling_parse',
+  'dlparse_v1',
+  'dlparse_v2',
+  'dlparse_v4',
+]);
+const LEGACY_VLM_MODELS = new Set([
+  'smoldocling',
+  'smoldocling_vllm',
+  'granite_vision',
+  'granite_vision_vllm',
+  'granite_vision_ollama',
+  'got_ocr_2',
+  'granite_docling',
+  'granite_docling_vllm',
+  'nanonets_ocr2',
+  'nanonets_ocr2_vllm',
+  'nanonets_ocr2_lmstudio',
+  'glm_ocr',
+  'glm_ocr_vllm',
+  'lightonocr',
+  'lightonocr_vllm',
+  'deepseekocr_ollama',
+]);
+const VLM_RESPONSE_FORMATS = new Set([
+  'doctags',
+  'doclang',
+  'markdown',
+  'deepseekocr_markdown',
+  'html',
+  'otsl',
+  'plaintext',
+  'chandra_html',
+  'dots_json',
+]);
+const VLM_INFERENCE_FRAMEWORKS = new Set(['mlx', 'transformers', 'vllm']);
+const TRANSFORMERS_MODEL_TYPES = new Set([
+  'automodel',
+  'automodel-causallm',
+  'automodel-imagetexttotext',
+]);
+const PICTURE_CLASSIFICATION_LABELS = new Set([
+  'bar_chart',
+  'box_plot',
+  'flow_chart',
+  'line_chart',
+  'pie_chart',
+  'scatter_plot',
+  'table',
+  'other_chart',
+  'full_page_image',
+  'page_thumbnail',
+  'photograph',
+  'chemistry_structure',
+  'bar_code',
+  'icon',
+  'logo',
+  'qr_code',
+  'signature',
+  'stamp',
+  'engineering_drawing',
+  'screenshot_from_computer',
+  'screenshot_from_manual',
+  'geographical_map',
+  'topographical_map',
+  'calendar',
+  'crossword_puzzle',
+  'music',
+  'other',
+  'cad_drawing',
+  'electrical_diagram',
+  'map',
+  'heatmap',
+  'chemistry_markush_structure',
+  'chemistry_molecular_structure',
+  'natural_image',
+  'picture_group',
+  'remote_sensing',
+  'scatter_chart',
+  'screenshot',
+  'stacked_bar_chart',
+  'stratigraphic_chart',
+]);
+const BOOLEAN_OPTIONS = [
+  'do_ocr',
+  'force_ocr',
+  'table_cell_matching',
+  'do_table_structure',
+  'include_images',
+  'include_page_images',
+  'do_code_enrichment',
+  'do_formula_enrichment',
+  'do_picture_classification',
+  'do_chart_extraction',
+  'do_picture_description',
+  'abort_on_error',
+] as const;
+const NUMBER_OPTIONS = [
+  'document_timeout',
+  'images_scale',
+  'picture_description_area_threshold',
+] as const;
+const STRING_OPTIONS = [
+  'ocr_engine',
+  'ocr_preset',
+  'md_page_break_placeholder',
+  'vlm_pipeline_preset',
+  'picture_description_preset',
+  'code_formula_preset',
+  'table_structure_preset',
+  'layout_preset',
+  'picture_classification_preset',
+] as const;
+const RECORD_OPTIONS = [
+  'ocr_custom_config',
+  'vlm_pipeline_custom_config',
+  'picture_description_custom_config',
+  'code_formula_custom_config',
+  'table_structure_custom_config',
+  'layout_custom_config',
+  'picture_classification_custom_config',
+  'picture_description_local',
+  'picture_description_api',
+  'vlm_pipeline_model_local',
+  'vlm_pipeline_model_api',
+] as const;
+const JSON_STRING_CONFIG_OPTIONS = [
+  'ocr_custom_config',
+  'table_structure_custom_config',
+  'layout_custom_config',
+  'picture_classification_custom_config',
+] as const;
+
+function validateStringEnum<T extends string>(
+  value: T | undefined,
+  allowed: ReadonlySet<string>,
+  name: string
+): void {
+  if (value !== undefined && !allowed.has(value)) {
+    throw new DoclingProtocolError(`${name} contains an unsupported value`);
+  }
+}
+
+function validateRequiredEnum(
+  value: unknown,
+  allowed: ReadonlySet<string>,
+  name: string
+): void {
+  if (typeof value !== 'string' || !allowed.has(value)) {
+    throw new DoclingProtocolError(`${name} contains an unsupported value`);
+  }
+}
+
+function validateRequiredString(value: unknown, name: string): void {
+  if (typeof value !== 'string') {
+    throw new DoclingProtocolError(`${name} must be a string`);
+  }
+}
+
+function validateOptionalString(value: unknown, name: string): void {
+  if (value !== undefined && value !== null && typeof value !== 'string') {
+    throw new DoclingProtocolError(`${name} must be a string or null`);
+  }
+}
+
+function validateOptionalEnumArray(
+  value: unknown,
+  allowed: ReadonlySet<string>,
+  name: string
+): void {
+  if (
+    value !== undefined &&
+    value !== null &&
+    (!Array.isArray(value) ||
+      value.some(item => typeof item !== 'string' || !allowed.has(item)))
+  ) {
+    throw new DoclingProtocolError(`${name} contains an unsupported value`);
+  }
+}
+
+function validateOptionalRecord(value: unknown, name: string): void {
+  if (value !== undefined && value !== null && !isRecord(value)) {
+    throw new DoclingProtocolError(`${name} must be an object or null`);
+  }
+}
+
+function validateOptionalStringRecord(value: unknown, name: string): void {
+  if (
+    value !== undefined &&
+    value !== null &&
+    (!isRecord(value) || Object.values(value).some(item => typeof item !== 'string'))
+  ) {
+    throw new DoclingProtocolError(`${name} must contain string values`);
+  }
+}
+
+function validateOptionalFiniteNumber(value: unknown, name: string): void {
+  if (
+    value !== undefined &&
+    value !== null &&
+    (typeof value !== 'number' || !Number.isFinite(value))
+  ) {
+    throw new DoclingProtocolError(`${name} must be a finite number or null`);
+  }
+}
+
+function validateOptionalPositiveInteger(value: unknown, name: string): void {
+  if (
+    value !== undefined &&
+    value !== null &&
+    (!Number.isSafeInteger(value) || (value as number) < 1)
+  ) {
+    throw new DoclingProtocolError(`${name} must be a positive integer or null`);
+  }
+}
+
+function validateAbsoluteUrl(value: unknown, name: string): void {
+  if (typeof value !== 'string') {
+    throw new DoclingProtocolError(`${name} must be an absolute URL`);
+  }
+  try {
+    const url = new URL(value);
+    if (url.protocol === '') {
+      throw new Error('missing scheme');
+    }
+  } catch (error) {
+    throw new DoclingProtocolError(`${name} must be an absolute URL`, {
+      cause: error,
+    });
+  }
+}
+
+function validateStringEnumArray<T extends string>(
+  value: T[] | undefined,
+  allowed: ReadonlySet<string>,
+  name: string
+): void {
+  if (
+    value !== undefined &&
+    (!Array.isArray(value) ||
+      value.some(item => typeof item !== 'string' || !allowed.has(item)))
+  ) {
+    throw new DoclingProtocolError(`${name} contains an unsupported value`);
+  }
+}
+
+function base64ByteLength(value: string): number {
+  const normalized = value.replace(/\s/g, '');
+  if (normalized === '') {
+    return 0;
+  }
+  const padding = normalized.endsWith('==') ? 2 : normalized.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((normalized.length * 3) / 4) - padding);
+}
+
+async function toBlob(
+  data: Blob | ArrayBuffer | ArrayBufferView,
+  contentType = 'application/octet-stream'
+): Promise<Blob> {
+  if (data instanceof Blob) {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Blob([data], { type: contentType });
+  }
+  const bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  return new Blob([Uint8Array.from(bytes).buffer], { type: contentType });
+}
+
+function isHttpSource(value: unknown): value is HttpSource {
+  return isRecord(value) && value.kind === 'http' && typeof value.url === 'string';
+}
+
+function isFileSource(value: unknown): value is FileSource {
+  return (
+    isRecord(value) &&
+    value.kind === 'file' &&
+    typeof value.base64_string === 'string' &&
+    typeof value.filename === 'string'
+  );
+}
+
+function isBinaryFileSource(value: unknown): value is BinaryFileSource {
+  return (
+    isRecord(value) &&
+    typeof value.filename === 'string' &&
+    'data' in value &&
+    (value.data instanceof Blob ||
+      value.data instanceof ArrayBuffer ||
+      ArrayBuffer.isView(value.data))
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) {
+    throw abortReason(signal);
+  }
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException('The operation was aborted', 'AbortError');
+}
+
+function fileNameFromPath(value: string): string {
+  const normalized = value.replaceAll('\\', '/');
+  return normalized.split('/').at(-1) || 'document';
+}
+
+function validatePageRange(value: unknown): asserts value is [number, number] {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 2 ||
+    !Number.isSafeInteger(value[0]) ||
+    !Number.isSafeInteger(value[1]) ||
+    value[0] < 1 ||
+    value[1] < value[0]
+  ) {
+    throw new DoclingProtocolError(
+      'pageRange must contain positive integers with end >= start'
+    );
+  }
+}
+
+function validateNonNegativeSafeInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new DoclingProtocolError(`${name} must be a non-negative safe integer`);
+  }
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+  let binary = '';
+  const chunkSize = 32_768;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/docling-client/src/transport.ts
+++ b/docling-client/src/transport.ts
@@ -1,0 +1,454 @@
+import {
+  DoclingHttpError,
+  DoclingProtocolError,
+  DoclingServiceUnavailableError,
+  DoclingUsageLimitExceededError,
+} from './errors';
+
+export type DoclingResponseType = 'json' | 'text' | 'bytes' | 'auto';
+export type DoclingRequestBodyType = 'json' | 'form' | 'raw';
+
+export interface DoclingTransportRequest {
+  method: 'GET' | 'HEAD' | 'OPTIONS' | 'POST';
+  url: string;
+  headers: Readonly<Record<string, string>>;
+  body?: unknown;
+  bodyType?: DoclingRequestBodyType;
+  responseType?: DoclingResponseType;
+  retries?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface DoclingBinaryResponse {
+  content: Uint8Array;
+  headers: Readonly<Record<string, string>>;
+  contentType: string;
+}
+
+export interface DoclingTransport {
+  request<T>(request: DoclingTransportRequest): Promise<T>;
+  close?(): void | Promise<void>;
+}
+
+export type FetchLike = (
+  input: string | URL | Request,
+  init?: RequestInit
+) => Promise<Response>;
+
+export interface FetchTransportOptions {
+  fetch?: FetchLike;
+  retries?: number;
+  timeoutMs?: number;
+  backoffBaseMs?: number;
+  sleep?: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
+}
+
+export class FetchTransport implements DoclingTransport {
+  readonly #fetch: FetchLike;
+  readonly #retries: number;
+  readonly #timeoutMs: number;
+  readonly #backoffBaseMs: number;
+  readonly #sleep: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
+
+  constructor(
+    optionsOrFetch: FetchTransportOptions | FetchLike | undefined = globalThis.fetch
+  ) {
+    const options =
+      typeof optionsOrFetch === 'function' ? { fetch: optionsOrFetch } : optionsOrFetch;
+    const fetchImplementation = options?.fetch ?? globalThis.fetch;
+    if (fetchImplementation === undefined) {
+      throw new DoclingProtocolError(
+        'No fetch implementation is available; provide a DoclingTransport'
+      );
+    }
+    this.#fetch = fetchImplementation;
+    this.#retries = validateNonNegativeInteger(options?.retries ?? 3, 'retries');
+    this.#timeoutMs = validatePositiveNumber(options?.timeoutMs ?? 60_000, 'timeoutMs');
+    this.#backoffBaseMs = validatePositiveNumber(
+      options?.backoffBaseMs ?? 1_000,
+      'backoffBaseMs'
+    );
+    this.#sleep = options?.sleep ?? abortableDelay;
+  }
+
+  async request<T>(request: DoclingTransportRequest): Promise<T> {
+    const maxRetries =
+      request.retries === undefined
+        ? this.#retries
+        : validateNonNegativeInteger(request.retries, 'request.retries');
+
+    for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+      try {
+        const response = await this.#requestOnce(request);
+        const retryDelay = retryDelayMs(
+          response,
+          attempt,
+          maxRetries,
+          this.#backoffBaseMs
+        );
+        if (retryDelay === 'exhausted') {
+          const body = await decodeErrorResponse(response);
+          throw new DoclingServiceUnavailableError(
+            `Docling returned HTTP ${response.status} after retries`,
+            {
+              status: response.status,
+              detail: httpDetail(body),
+            }
+          );
+        }
+        if (retryDelay !== null) {
+          await discardResponse(response);
+          if (retryDelay > 0) {
+            await this.#sleep(retryDelay, request.signal);
+          }
+          continue;
+        }
+
+        const responseHeaders = headersToRecord(response.headers);
+        if (response.status !== 200) {
+          const body = await decodeErrorResponse(response);
+          if (response.status === 402) {
+            const usage = isUsageLimitBody(body) ? body : undefined;
+            throw new DoclingUsageLimitExceededError({
+              method: request.method,
+              url: request.url,
+              status: response.status,
+              body,
+              headers: responseHeaders,
+              ...(usage === undefined
+                ? {}
+                : {
+                    currentUsage: usage.details.currentUsage,
+                    limit: usage.details.limit,
+                    detail: usage.message,
+                  }),
+            });
+          }
+          if (response.status >= 500) {
+            throw new DoclingServiceUnavailableError(
+              `Docling returned HTTP ${response.status}`,
+              {
+                status: response.status,
+                detail: httpDetail(body),
+              }
+            );
+          }
+          throw new DoclingHttpError({
+            method: request.method,
+            url: request.url,
+            status: response.status,
+            body,
+            headers: responseHeaders,
+            detail: httpDetail(body),
+          });
+        }
+
+        return (await decodeResponse(response, request.responseType ?? 'json')) as T;
+      } catch (error) {
+        if (
+          error instanceof DoclingHttpError ||
+          error instanceof DoclingProtocolError ||
+          error instanceof DoclingServiceUnavailableError ||
+          error instanceof DoclingUsageLimitExceededError ||
+          isAbort(error, request.signal)
+        ) {
+          throw error;
+        }
+        const retryableMethod = ['GET', 'HEAD', 'OPTIONS'].includes(request.method);
+        if (retryableMethod && attempt < maxRetries) {
+          await this.#sleep(this.#backoffBaseMs * 2 ** attempt, request.signal);
+          continue;
+        }
+        throw new DoclingServiceUnavailableError(
+          attempt >= maxRetries && retryableMethod
+            ? 'Docling transport request failed after retries'
+            : 'Docling transport request failed',
+          {
+            detail: error instanceof Error ? error.message : String(error),
+            cause: error,
+          }
+        );
+      }
+    }
+
+    throw new DoclingServiceUnavailableError(
+      'Docling request failed after the retry loop'
+    );
+  }
+
+  async #requestOnce(request: DoclingTransportRequest): Promise<Response> {
+    const timeoutMs = request.timeoutMs ?? this.#timeoutMs;
+    validatePositiveNumber(timeoutMs, 'request.timeoutMs');
+    const timeoutController = new AbortController();
+    const timeout = setTimeout(() => {
+      timeoutController.abort(
+        new DoclingServiceUnavailableError(
+          `Docling request exceeded its ${timeoutMs} ms transport timeout`
+        )
+      );
+    }, timeoutMs);
+    const combined = combineAbortSignals(request.signal, timeoutController.signal);
+
+    try {
+      try {
+        return await this.#fetch(request.url, {
+          method: request.method,
+          headers: request.headers,
+          ...(request.body === undefined
+            ? {}
+            : { body: encodeBody(request.body, request.bodyType ?? 'json') }),
+          signal: combined.signal,
+        });
+      } catch (error) {
+        if (timeoutController.signal.aborted && request.signal?.aborted !== true) {
+          throw new TransportTimeoutError(
+            `Docling request exceeded its ${timeoutMs} ms transport timeout`,
+            { cause: error }
+          );
+        }
+        throw error;
+      }
+    } finally {
+      clearTimeout(timeout);
+      combined.dispose();
+    }
+  }
+}
+
+function encodeBody(body: unknown, bodyType: DoclingRequestBodyType): BodyInit {
+  if (bodyType === 'json') {
+    return JSON.stringify(body);
+  }
+  if (bodyType === 'form') {
+    if (!(body instanceof FormData)) {
+      throw new DoclingProtocolError('A form request body must be FormData');
+    }
+    return body;
+  }
+  if (
+    typeof body === 'string' ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body) ||
+    body instanceof URLSearchParams
+  ) {
+    return body as BodyInit;
+  }
+  throw new DoclingProtocolError('Unsupported raw transport request body');
+}
+
+async function decodeResponse(
+  response: Response,
+  responseType: DoclingResponseType
+): Promise<unknown> {
+  if (responseType === 'bytes') {
+    return {
+      content: new Uint8Array(await response.arrayBuffer()),
+      headers: headersToRecord(response.headers),
+      contentType: response.headers.get('content-type') ?? 'application/octet-stream',
+    } satisfies DoclingBinaryResponse;
+  }
+  if (response.status === 204) {
+    return undefined;
+  }
+
+  const text = await response.text();
+  if (text === '') {
+    return undefined;
+  }
+  if (responseType === 'text') {
+    return text;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  const shouldDecodeJson =
+    responseType === 'json' || contentType.toLowerCase().includes('json');
+  if (!shouldDecodeJson) {
+    return text;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new DoclingProtocolError('Docling returned invalid JSON', {
+      cause: error,
+    });
+  }
+}
+
+async function decodeErrorResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text === '') {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function retryDelayMs(
+  response: Response,
+  attempt: number,
+  maxRetries: number,
+  backoffBaseMs: number
+): number | 'exhausted' | null {
+  if ([500, 502].includes(response.status)) {
+    return attempt < maxRetries ? backoffBaseMs * 2 ** attempt : 'exhausted';
+  }
+  if ([429, 503].includes(response.status)) {
+    const retryAfter = parseRetryAfter(response.headers.get('retry-after'));
+    if (retryAfter === null) {
+      return null;
+    }
+    return attempt < maxRetries ? retryAfter : 'exhausted';
+  }
+  return null;
+}
+
+function parseRetryAfter(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+  const normalized = value.trim();
+  if (normalized === '') {
+    return null;
+  }
+  const seconds = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i.test(normalized)
+    ? Number(normalized)
+    : Number.NaN;
+  if (Number.isFinite(seconds)) {
+    return Math.max(0, seconds * 1_000);
+  }
+  const retryAt = Date.parse(value);
+  if (Number.isNaN(retryAt)) {
+    return null;
+  }
+  return Math.max(0, retryAt - Date.now());
+}
+
+function isUsageLimitBody(value: unknown): value is {
+  error: 'usage_limit_exceeded';
+  message: string;
+  details: { currentUsage: number; limit: number };
+} {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const body = value as Record<string, unknown>;
+  if (
+    body.error !== 'usage_limit_exceeded' ||
+    typeof body.message !== 'string' ||
+    body.details === null ||
+    typeof body.details !== 'object' ||
+    Array.isArray(body.details)
+  ) {
+    return false;
+  }
+  const details = body.details as Record<string, unknown>;
+  return typeof details.currentUsage === 'number' && typeof details.limit === 'number';
+}
+
+function httpDetail(value: unknown): string | undefined {
+  return value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).detail === 'string'
+    ? ((value as Record<string, unknown>).detail as string)
+    : undefined;
+}
+
+function headersToRecord(headers: Headers): Readonly<Record<string, string>> {
+  return Object.fromEntries(headers.entries());
+}
+
+function validateNonNegativeInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new DoclingProtocolError(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function validatePositiveNumber(value: number, name: string): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new DoclingProtocolError(`${name} must be a positive number`);
+  }
+  return value;
+}
+
+function combineAbortSignals(
+  callerSignal: AbortSignal | undefined,
+  timeoutSignal: AbortSignal
+): { signal: AbortSignal; dispose: () => void } {
+  if (callerSignal === undefined) {
+    return { signal: timeoutSignal, dispose: () => undefined };
+  }
+  if (typeof AbortSignal.any === 'function') {
+    return {
+      signal: AbortSignal.any([callerSignal, timeoutSignal]),
+      dispose: () => undefined,
+    };
+  }
+  const controller = new AbortController();
+  const abort = (signal: AbortSignal) => {
+    controller.abort(signal.reason);
+  };
+  if (callerSignal.aborted) {
+    abort(callerSignal);
+  } else if (timeoutSignal.aborted) {
+    abort(timeoutSignal);
+  } else {
+    const abortCaller = () => abort(callerSignal);
+    const abortTimeout = () => abort(timeoutSignal);
+    callerSignal.addEventListener('abort', abortCaller, { once: true });
+    timeoutSignal.addEventListener('abort', abortTimeout, { once: true });
+    return {
+      signal: controller.signal,
+      dispose: () => {
+        callerSignal.removeEventListener('abort', abortCaller);
+        timeoutSignal.removeEventListener('abort', abortTimeout);
+      },
+    };
+  }
+  return { signal: controller.signal, dispose: () => undefined };
+}
+
+async function discardResponse(response: Response): Promise<void> {
+  try {
+    if (response.body !== null) {
+      await response.body.cancel();
+    }
+  } catch {
+    // Best-effort cleanup before retrying.
+  }
+}
+
+function isAbort(error: unknown, signal: AbortSignal | undefined): boolean {
+  return (
+    signal?.aborted === true ||
+    (error instanceof DOMException && error.name === 'AbortError')
+  );
+}
+
+function abortableDelay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  if (milliseconds <= 0) {
+    return Promise.resolve();
+  }
+  if (signal?.aborted === true) {
+    return Promise.reject(signal.reason);
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', abort);
+      resolve();
+    }, milliseconds);
+    const abort = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+}
+
+class TransportTimeoutError extends Error {}

--- a/docling-client/src/types.ts
+++ b/docling-client/src/types.ts
@@ -1,0 +1,753 @@
+/**
+ * Version-neutral Docling JSON boundary used by the service client.
+ *
+ * Supply `DoclingClient<import('@docling/docling-core').DoclingDocument>` when
+ * an application wants the exact schema version from docling-core. Keeping the
+ * remote client generic prevents its release cadence from pinning a document
+ * schema version.
+ */
+export interface DoclingDocument {
+  schema_name?: 'DoclingDocument';
+  version?: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export type InputFormat =
+  | 'docx'
+  | 'doc'
+  | 'pptx'
+  | 'html'
+  | 'image'
+  | 'pdf'
+  | 'asciidoc'
+  | 'md'
+  | 'csv'
+  | 'xlsx'
+  | 'xml_uspto'
+  | 'xml_jats'
+  | 'json_docling'
+  | 'dclx'
+  | 'audio'
+  | 'vtt'
+  | 'xml_xbrl'
+  | 'mets_gbs'
+  | 'latex'
+  | 'ppt'
+  | 'xls'
+  | 'odt'
+  | 'ods'
+  | 'odp'
+  | 'xml_doclang'
+  | 'video'
+  | 'email'
+  | 'epub'
+  | 'boxnote';
+
+export type OutputFormat =
+  | 'md'
+  | 'json'
+  | 'yaml'
+  | 'html'
+  | 'html_split_page'
+  | 'text'
+  | 'doctags'
+  | 'vtt'
+  | 'doclang'
+  | 'dclx'
+  | 'chunks';
+
+export type ProcessingPipeline = 'legacy' | 'standard' | 'vlm' | 'asr';
+export type TableMode = 'fast' | 'accurate';
+export type ImageExportMode = 'placeholder' | 'embedded' | 'referenced';
+export type PdfBackend =
+  | 'pypdfium2'
+  | 'docling_parse'
+  | 'threaded_docling_parse'
+  | 'dlparse_v1'
+  | 'dlparse_v2'
+  | 'dlparse_v4';
+export type VlmResponseFormat =
+  | 'doctags'
+  | 'doclang'
+  | 'markdown'
+  | 'deepseekocr_markdown'
+  | 'html'
+  | 'otsl'
+  | 'plaintext'
+  | 'chandra_html'
+  | 'dots_json';
+export type VlmInferenceFramework = 'mlx' | 'transformers' | 'vllm';
+export type TransformersModelType =
+  | 'automodel'
+  | 'automodel-causallm'
+  | 'automodel-imagetexttotext';
+export type LegacyVlmModelType =
+  | 'smoldocling'
+  | 'smoldocling_vllm'
+  | 'granite_vision'
+  | 'granite_vision_vllm'
+  | 'granite_vision_ollama'
+  | 'got_ocr_2'
+  | 'granite_docling'
+  | 'granite_docling_vllm'
+  | 'nanonets_ocr2'
+  | 'nanonets_ocr2_vllm'
+  | 'nanonets_ocr2_lmstudio'
+  | 'glm_ocr'
+  | 'glm_ocr_vllm'
+  | 'lightonocr'
+  | 'lightonocr_vllm'
+  | 'deepseekocr_ollama';
+export type PictureClassificationLabel =
+  | 'bar_chart'
+  | 'box_plot'
+  | 'flow_chart'
+  | 'line_chart'
+  | 'pie_chart'
+  | 'scatter_plot'
+  | 'table'
+  | 'other_chart'
+  | 'full_page_image'
+  | 'page_thumbnail'
+  | 'photograph'
+  | 'chemistry_structure'
+  | 'bar_code'
+  | 'icon'
+  | 'logo'
+  | 'qr_code'
+  | 'signature'
+  | 'stamp'
+  | 'engineering_drawing'
+  | 'screenshot_from_computer'
+  | 'screenshot_from_manual'
+  | 'geographical_map'
+  | 'topographical_map'
+  | 'calendar'
+  | 'crossword_puzzle'
+  | 'music'
+  | 'other'
+  | 'cad_drawing'
+  | 'electrical_diagram'
+  | 'map'
+  | 'heatmap'
+  | 'chemistry_markush_structure'
+  | 'chemistry_molecular_structure'
+  | 'natural_image'
+  | 'picture_group'
+  | 'remote_sensing'
+  | 'scatter_chart'
+  | 'screenshot'
+  | 'stacked_bar_chart'
+  | 'stratigraphic_chart';
+
+/** @deprecated Prefer picture_description_preset or picture_description_custom_config. */
+export interface PictureDescriptionLocal {
+  repo_id: string;
+  prompt?: string;
+  generation_config?: Record<string, unknown>;
+  classification_allow?: PictureClassificationLabel[] | null;
+  classification_deny?: PictureClassificationLabel[] | null;
+  classification_min_confidence?: number;
+}
+
+/** @deprecated Prefer picture_description_preset or picture_description_custom_config. */
+export interface PictureDescriptionApi {
+  url: string;
+  headers?: Record<string, string>;
+  params?: Record<string, unknown>;
+  timeout?: number;
+  concurrency?: number;
+  prompt?: string;
+  classification_allow?: PictureClassificationLabel[] | null;
+  classification_deny?: PictureClassificationLabel[] | null;
+  classification_min_confidence?: number;
+}
+
+/** @deprecated Prefer vlm_pipeline_preset or vlm_pipeline_custom_config. */
+export interface VlmModelLocal {
+  repo_id: string;
+  prompt?: string;
+  scale?: number;
+  response_format: VlmResponseFormat;
+  inference_framework: VlmInferenceFramework;
+  transformers_model_type?: TransformersModelType;
+  extra_generation_config?: Record<string, unknown>;
+  temperature?: number;
+}
+
+/** @deprecated Prefer vlm_pipeline_preset or vlm_pipeline_custom_config. */
+export interface VlmModelApi {
+  url: string;
+  headers?: Record<string, string>;
+  params?: Record<string, unknown>;
+  timeout?: number;
+  concurrency?: number;
+  prompt?: string;
+  scale?: number;
+  response_format: VlmResponseFormat;
+  temperature?: number;
+}
+
+/**
+ * Common Docling Serve conversion controls.
+ *
+ * The string index preserves forward compatibility with options added by the
+ * selected service. Its live OpenAPI document remains authoritative.
+ */
+export interface ConvertDocumentsOptions {
+  [key: string]: unknown;
+  from_formats?: InputFormat[];
+  to_formats?: OutputFormat[];
+  pipeline?: ProcessingPipeline;
+  page_range?: [number, number];
+  do_ocr?: boolean;
+  force_ocr?: boolean;
+  /** @deprecated Use ocr_preset instead. */
+  ocr_engine?: string;
+  ocr_preset?: string;
+  ocr_lang?: string[] | null;
+  ocr_custom_config?: Record<string, unknown> | string | null;
+  pdf_backend?: PdfBackend;
+  table_mode?: TableMode;
+  table_cell_matching?: boolean;
+  do_table_structure?: boolean;
+  image_export_mode?: ImageExportMode;
+  images_scale?: number;
+  include_images?: boolean;
+  include_page_images?: boolean;
+  md_page_break_placeholder?: string;
+  do_code_enrichment?: boolean;
+  do_formula_enrichment?: boolean;
+  do_picture_classification?: boolean;
+  do_picture_description?: boolean;
+  do_chart_extraction?: boolean;
+  picture_description_area_threshold?: number;
+  /** @deprecated Prefer picture_description_preset or picture_description_custom_config. */
+  picture_description_local?: PictureDescriptionLocal | null;
+  /** @deprecated Prefer picture_description_preset or picture_description_custom_config. */
+  picture_description_api?: PictureDescriptionApi | null;
+  /** @deprecated Prefer vlm_pipeline_preset or vlm_pipeline_custom_config. */
+  vlm_pipeline_model?: LegacyVlmModelType | null;
+  /** @deprecated Prefer vlm_pipeline_preset or vlm_pipeline_custom_config. */
+  vlm_pipeline_model_local?: VlmModelLocal | null;
+  /** @deprecated Prefer vlm_pipeline_preset or vlm_pipeline_custom_config. */
+  vlm_pipeline_model_api?: VlmModelApi | null;
+  vlm_pipeline_preset?: string | null;
+  vlm_pipeline_custom_config?: Record<string, unknown> | null;
+  picture_description_preset?: string | null;
+  picture_description_custom_config?: Record<string, unknown> | null;
+  code_formula_preset?: string | null;
+  code_formula_custom_config?: Record<string, unknown> | null;
+  table_structure_preset?: string | null;
+  table_structure_custom_config?: Record<string, unknown> | string | null;
+  layout_preset?: string | null;
+  layout_custom_config?: Record<string, unknown> | string | null;
+  picture_classification_preset?: string | null;
+  picture_classification_custom_config?: Record<string, unknown> | string | null;
+  abort_on_error?: boolean;
+  document_timeout?: number | null;
+}
+
+export interface HttpSource {
+  kind: 'http';
+  url: string;
+  headers?: Record<string, unknown>;
+}
+
+export interface FileSource {
+  kind: 'file';
+  base64_string: string;
+  filename: string;
+}
+
+export type ConversionSource = HttpSource | FileSource;
+
+export interface InBodyTarget {
+  kind: 'inbody';
+}
+
+export interface ZipTarget {
+  kind: 'zip';
+}
+
+export interface PresignedUrlTarget {
+  kind: 'presigned_url';
+}
+
+export interface PutTarget {
+  kind: 'put';
+  url: string;
+}
+
+export interface S3Coordinates {
+  endpoint: string;
+  verify_ssl?: boolean;
+  access_key: string;
+  secret_key: string;
+  bucket: string;
+  key_prefix?: string;
+  max_num_elements?: number | null;
+}
+
+export interface S3Source extends S3Coordinates {
+  kind: 's3';
+}
+
+export interface S3Target extends S3Coordinates {
+  kind: 's3';
+}
+
+export interface AzureBlobCoordinates {
+  account_name: string;
+  container: string;
+  connection_string: string;
+  blob_prefix?: string;
+  max_num_elements?: number | null;
+}
+
+export interface AzureBlobSource extends AzureBlobCoordinates {
+  kind: 'azure_blob';
+}
+
+export interface AzureBlobTarget extends AzureBlobCoordinates {
+  kind: 'azure_blob';
+}
+
+export interface GoogleCloudStorageServiceAccountInfo {
+  project_id: string;
+  private_key_id: string;
+  private_key: string;
+  client_email: string;
+  client_id: string;
+  auth_uri: string;
+  token_uri: string;
+  auth_provider_x509_cert_url: string;
+  client_x509_cert_url: string;
+  universe_domain: string;
+}
+
+export interface GoogleCloudStorageCoordinates {
+  bucket: string;
+  key_prefix?: string;
+  max_num_elements?: number | null;
+  project?: string | null;
+  service_account_key?: GoogleCloudStorageServiceAccountInfo | null;
+}
+
+export interface GoogleCloudStorageSource extends GoogleCloudStorageCoordinates {
+  kind: 'google_cloud_storage';
+}
+
+export interface GoogleCloudStorageTarget extends GoogleCloudStorageCoordinates {
+  kind: 'google_cloud_storage';
+}
+
+export interface GoogleDriveCredentials {
+  client_id: string;
+  project_id: string;
+  auth_uri: string;
+  token_uri: string;
+  auth_provider_x509_cert_url: string;
+  client_secret: string;
+  redirect_uris: string[];
+}
+
+export interface GoogleDriveCoordinates {
+  path_id: string;
+  token_path?: string | null;
+  refresh_token?: string | null;
+  credentials_path?: string | null;
+  credentials?: GoogleDriveCredentials | null;
+}
+
+export interface GoogleDriveSource extends GoogleDriveCoordinates {
+  kind: 'google_drive';
+}
+
+export interface GoogleDriveTarget extends GoogleDriveCoordinates {
+  kind: 'google_drive';
+}
+
+export interface GenericSource {
+  kind: string;
+  [key: string]: unknown;
+}
+
+export interface GenericTarget {
+  kind: string;
+  [key: string]: unknown;
+}
+
+export type StorageTarget =
+  | S3Target
+  | AzureBlobTarget
+  | GoogleCloudStorageTarget
+  | GoogleDriveTarget;
+
+export type SubmitTarget =
+  | InBodyTarget
+  | ZipTarget
+  | PresignedUrlTarget
+  | PutTarget
+  | StorageTarget;
+
+export type BatchSource =
+  | HttpSource
+  | S3Source
+  | AzureBlobSource
+  | GoogleCloudStorageSource
+  | GoogleDriveSource
+  | GenericSource;
+
+export type BatchTarget = PresignedUrlTarget | StorageTarget | GenericTarget;
+
+export interface CallbackSpec {
+  url: string;
+  headers?: Record<string, string>;
+  ca_cert?: string;
+  [key: string]: unknown;
+}
+
+export interface ConvertSourcesRequest<TTarget extends SubmitTarget = SubmitTarget> {
+  options?: ConvertDocumentsOptions;
+  sources: ConversionSource[];
+  target?: TTarget;
+  callbacks?: CallbackSpec[];
+}
+
+export interface BatchConvertSourcesRequest<TTarget extends BatchTarget = BatchTarget> {
+  options?: ConvertDocumentsOptions;
+  sources: BatchSource[];
+  target: TTarget;
+  callbacks?: CallbackSpec[];
+}
+
+export type ChunkerKind = 'hybrid' | 'hierarchical';
+
+export interface BaseChunkingOptions {
+  use_markdown_tables?: boolean;
+  use_markdown_images?: boolean;
+  image_placeholder?: string;
+  include_raw_text?: boolean;
+}
+
+export interface HybridChunkingOptions extends BaseChunkingOptions {
+  max_tokens?: number | null;
+  tokenizer?: string;
+  merge_peers?: boolean;
+}
+
+export type HierarchicalChunkingOptions = BaseChunkingOptions;
+
+interface BaseChunkSourcesRequest {
+  convert_options?: ConvertDocumentsOptions;
+  sources: ConversionSource[];
+  include_converted_doc?: boolean;
+  target?: InBodyTarget;
+  callbacks?: CallbackSpec[];
+}
+
+export interface HybridChunkSourcesRequest extends BaseChunkSourcesRequest {
+  chunker: 'hybrid';
+  chunking_options?: HybridChunkingOptions;
+}
+
+export interface HierarchicalChunkSourcesRequest extends BaseChunkSourcesRequest {
+  chunker: 'hierarchical';
+  chunking_options?: HierarchicalChunkingOptions;
+}
+
+/**
+ * A Docling Serve chunk job converts each source and then chunks the resulting
+ * DoclingDocument in the same task.
+ */
+export type ChunkSourcesRequest =
+  | HybridChunkSourcesRequest
+  | HierarchicalChunkSourcesRequest;
+
+export type ChunkSourceOptions =
+  | Omit<HybridChunkSourcesRequest, 'sources'>
+  | Omit<HierarchicalChunkSourcesRequest, 'sources'>;
+
+export type TaskType = 'convert' | 'chunk';
+export type TaskStatus =
+  | 'pending'
+  | 'started'
+  | 'success'
+  | 'failure'
+  | 'partial_success'
+  | 'skipped';
+
+export interface TaskProcessingMeta {
+  num_docs: number;
+  num_processed: number;
+  num_succeeded: number;
+  num_partially_succeeded: number;
+  num_failed: number;
+}
+
+export interface PublicFailureInfo {
+  category: FailureCategory;
+  message: string;
+  retryable: boolean;
+  phase: 'admission' | 'source_enumeration' | 'execution' | 'orchestration';
+  details: Record<string, string>;
+}
+
+export interface TaskStatusResponse {
+  task_id: string;
+  task_type: TaskType;
+  task_status: TaskStatus;
+  task_position?: number | null;
+  task_meta?: TaskProcessingMeta | null;
+  error_message?: string | null;
+  failure?: PublicFailureInfo | null;
+}
+
+export type ConversionStatus =
+  | 'pending'
+  | 'started'
+  | 'success'
+  | 'partial_success'
+  | 'skipped'
+  | 'failure';
+
+export type FailureCategory =
+  | 'policy'
+  | 'capacity'
+  | 'source_unavailable'
+  | 'target_unavailable'
+  | 'timeout'
+  | 'internal'
+  | 'backend_failure'
+  | 'inference_failure'
+  | 'unknown';
+
+export type DoclingComponentType =
+  | 'document_backend'
+  | 'model'
+  | 'doc_assembler'
+  | 'user_input'
+  | 'pipeline';
+
+export type QualityGrade = 'poor' | 'fair' | 'good' | 'excellent' | 'unspecified';
+
+export interface ConfidenceScores {
+  parse_score?: number | null;
+  layout_score?: number | null;
+  table_score?: number | null;
+  ocr_score?: number | null;
+  mean_score?: number | null;
+  low_score?: number | null;
+  mean_grade?: QualityGrade;
+  low_grade?: QualityGrade;
+}
+
+export interface ErrorItem {
+  component_type: DoclingComponentType;
+  module_name: string;
+  error_message: string;
+  category?: FailureCategory;
+  page_no?: number | null;
+}
+
+export type ProfilingScope = 'page' | 'document';
+
+export interface ProfilingItem {
+  scope: ProfilingScope;
+  count: number;
+  times: number[];
+  start_timestamps?: string[];
+}
+
+export interface ExportDocumentResponse<TDocument = DoclingDocument> {
+  filename: string;
+  md_content?: string | null;
+  json_content?: TDocument | null;
+  html_content?: string | null;
+  text_content?: string | null;
+  doctags_content?: string | null;
+  doclang_content?: string | null;
+}
+
+export interface ExportResult<TDocument = DoclingDocument> {
+  kind: 'ExportResult';
+  content: ExportDocumentResponse<TDocument>;
+  status: ConversionStatus;
+  errors: ErrorItem[];
+  timings: Record<string, ProfilingItem>;
+  confidence?: ConfidenceScores | null;
+}
+
+export type ArtifactType =
+  | 'json'
+  | 'html'
+  | 'markdown'
+  | 'text'
+  | 'doctags'
+  | 'doclang'
+  | 'resource_bundle';
+
+export interface ArtifactRef {
+  artifact_type: ArtifactType;
+  mime_type: string;
+  uri: string;
+  url_expires_at?: string | null;
+}
+
+export interface DocumentArtifactItem {
+  source_index: number;
+  source_uri: string;
+  filename: string;
+  status: ConversionStatus;
+  errors: ErrorItem[];
+  timings: Record<string, ProfilingItem>;
+  artifacts: ArtifactRef[];
+  confidence?: ConfidenceScores | null;
+}
+
+export interface OutcomeCounts {
+  num_converted: number;
+  num_succeeded: number;
+  num_partially_succeeded: number;
+  num_failed: number;
+}
+
+export interface PresignedUrlConvertDocumentResponse extends OutcomeCounts {
+  processing_time: number;
+}
+
+export interface PresignedUrlConvertResponse extends PresignedUrlConvertDocumentResponse {
+  documents: DocumentArtifactItem[];
+}
+
+export interface RawServiceResult {
+  content: Uint8Array;
+  content_type: string;
+  filename: string | null;
+}
+
+export interface ChunkedDocumentResultItem {
+  filename: string;
+  chunk_index: number;
+  text: string;
+  raw_text?: string | null;
+  num_tokens?: number | null;
+  headings?: string[] | null;
+  captions?: string[] | null;
+  doc_items: string[];
+  page_numbers?: number[] | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface ChunkDocumentResponse<TDocument = DoclingDocument> {
+  chunks: ChunkedDocumentResultItem[];
+  documents: ExportResult<TDocument>[];
+  processing_time: number;
+}
+
+export interface ConvertDocumentResponse<TDocument = DoclingDocument> {
+  document: ExportDocumentResponse<TDocument>;
+  status: ConversionStatus;
+  errors: ErrorItem[];
+  processing_time: number;
+  timings: Record<string, ProfilingItem>;
+  confidence?: ConfidenceScores | null;
+}
+
+export interface ConversionInput {
+  filename: string;
+  source: string;
+  format?: InputFormat;
+  file_size?: number | null;
+}
+
+/**
+ * JavaScript counterpart of Python's high-level ConversionResult.
+ *
+ * The document remains plain Docling JSON so it works with @docling/docling-core
+ * traversal utilities without embedding a conversion runtime.
+ */
+export interface ConversionResult<TDocument = DoclingDocument> {
+  input: ConversionInput;
+  document: TDocument;
+  status: ConversionStatus;
+  errors: ErrorItem[];
+  processing_time: number;
+  timings: Record<string, ProfilingItem>;
+  confidence?: ConfidenceScores | null;
+}
+
+export type SubmitResultForTarget<
+  TTarget extends SubmitTarget,
+  TDocument = DoclingDocument,
+> = TTarget extends InBodyTarget
+  ? ConversionResult<TDocument>
+  : TTarget extends ZipTarget
+    ? RawServiceResult
+    : TTarget extends PresignedUrlTarget
+      ? PresignedUrlConvertResponse
+      : PresignedUrlConvertDocumentResponse;
+
+export type AutoSubmitResult<TDocument = DoclingDocument> =
+  | ConversionResult<TDocument>
+  | PresignedUrlConvertResponse;
+
+/** Clearer alias for the legacy Python-compatible counts response name. */
+export type RemoteTargetResponse = PresignedUrlConvertDocumentResponse;
+
+export type BatchResultForTarget<TTarget extends BatchTarget> =
+  TTarget extends PresignedUrlTarget
+    ? PresignedUrlConvertResponse
+    : PresignedUrlConvertDocumentResponse;
+
+export type InBodyConversionResponse<TDocument = DoclingDocument> =
+  | ConvertDocumentResponse<TDocument>
+  | ChunkDocumentResponse<TDocument>;
+
+export interface TaskFailureResult {
+  kind: 'TaskFailureResult';
+  failure: PublicFailureInfo;
+}
+
+export interface HealthCheckResponse {
+  status: string;
+}
+
+export interface WaitForTaskOptions {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  serverWaitSeconds?: number;
+  statusWatcher?: 'websocket' | 'polling';
+  signal?: AbortSignal;
+  onStatus?: (status: TaskStatusResponse) => void | Promise<void>;
+}
+
+export interface DocumentLimits {
+  maxNumPages?: number;
+  maxFileSize?: number;
+  pageRange?: [number, number];
+}
+
+export interface ConversionItem {
+  source: ConversionSourceInput;
+  options?: ConvertDocumentsOptions;
+  headers?: Record<string, string>;
+  metadata?: unknown;
+}
+
+export interface BinaryFileSource {
+  data: Blob | ArrayBuffer | ArrayBufferView;
+  filename: string;
+  contentType?: string;
+}
+
+export type ConversionSourceInput = ConversionSource | URL | string | BinaryFileSource;
+
+export interface SubmitAndRetrieveOptions<TTarget extends SubmitTarget> {
+  maxInFlight?: number;
+  ordered?: boolean;
+  target?: TTarget;
+  signal?: AbortSignal;
+}

--- a/docling-client/src/watchers.ts
+++ b/docling-client/src/watchers.ts
@@ -1,0 +1,447 @@
+import WebSocket from 'isomorphic-ws';
+
+import {
+  DoclingProtocolError,
+  DoclingServiceUnavailableError,
+  DoclingTaskNotFoundError,
+  DoclingTimeoutError,
+} from './errors';
+import type { TaskStatusResponse, WaitForTaskOptions } from './types';
+
+export type StatusWatcherKind = 'websocket' | 'polling';
+
+export interface WebSocketLike {
+  readonly readyState: number;
+  send(data: string): void;
+  close(): void;
+  addEventListener(
+    type: 'open' | 'message' | 'error' | 'close',
+    listener: (event: {
+      data?: unknown;
+      error?: unknown;
+      message?: string;
+      code?: number;
+      reason?: string;
+      wasClean?: boolean;
+    }) => void
+  ): void;
+}
+
+export interface WebSocketFactoryOptions {
+  headers: Readonly<Record<string, string>>;
+}
+
+export type WebSocketFactory = (
+  url: string,
+  options: WebSocketFactoryOptions
+) => WebSocketLike;
+
+export interface WatchTaskOptions extends WaitForTaskOptions {
+  taskId: string;
+  baseUrl: string;
+  apiKey?: string;
+  watcher: StatusWatcherKind;
+  fallbackToPoll: boolean;
+  connectTimeoutMs: number;
+  webSocketFactory?: WebSocketFactory;
+  sleep?: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
+  poll: (
+    taskId: string,
+    options: { waitSeconds: number; signal?: AbortSignal }
+  ) => Promise<TaskStatusResponse>;
+  parseStatus: (value: unknown) => TaskStatusResponse;
+}
+
+interface WebSocketEnvelope {
+  message: 'connection' | 'update' | 'error';
+  task?: TaskStatusResponse;
+  error?: string | null;
+}
+
+interface SocketEvent {
+  kind: 'open' | 'message' | 'error' | 'close';
+  data?: unknown;
+  error?: unknown;
+  code?: number;
+  reason?: string;
+  wasClean?: boolean;
+}
+
+export async function* watchTask(
+  options: WatchTaskOptions
+): AsyncGenerator<TaskStatusResponse> {
+  if (options.watcher === 'polling') {
+    yield* pollUpdates(options);
+    return;
+  }
+  try {
+    yield* webSocketUpdates(options);
+  } catch (error) {
+    if (error instanceof DoclingServiceUnavailableError && options.fallbackToPoll) {
+      yield* pollUpdates(options);
+      return;
+    }
+    throw error;
+  }
+}
+
+async function* pollUpdates(
+  options: WatchTaskOptions
+): AsyncGenerator<TaskStatusResponse> {
+  const timeoutMs = options.timeoutMs ?? 300_000;
+  const serverWaitSeconds = options.serverWaitSeconds ?? 5;
+  const pollIntervalMs = options.pollIntervalMs ?? serverWaitSeconds * 1_000;
+  validateWatchTimes(timeoutMs, serverWaitSeconds, pollIntervalMs);
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new DoclingTimeoutError(options.taskId, timeoutMs);
+    }
+    const waitSeconds = Math.min(serverWaitSeconds, remaining / 1_000);
+    const pollStarted = Date.now();
+    const status = await options.poll(options.taskId, {
+      waitSeconds,
+      ...(options.signal === undefined ? {} : { signal: options.signal }),
+    });
+    await options.onStatus?.(status);
+    yield status;
+    if (isTerminal(status)) {
+      return;
+    }
+    const elapsed = Date.now() - pollStarted;
+    const sleepMs = Math.max(
+      0,
+      Math.min(pollIntervalMs, deadline - Date.now()) - elapsed
+    );
+    await (options.sleep ?? abortableDelay)(sleepMs, options.signal);
+  }
+}
+
+async function* webSocketUpdates(
+  options: WatchTaskOptions
+): AsyncGenerator<TaskStatusResponse> {
+  const timeoutMs = options.timeoutMs ?? 300_000;
+  const deadline = Date.now() + timeoutMs;
+  const factory =
+    options.webSocketFactory ??
+    ((socketUrl: string, factoryOptions: WebSocketFactoryOptions) =>
+      new WebSocket(socketUrl, [], {
+        headers: factoryOptions.headers,
+      }) as unknown as WebSocketLike);
+  const url = webSocketUrl(options.baseUrl, options.taskId, options.apiKey);
+
+  for (let attempt = 0; attempt <= 3; attempt += 1) {
+    let socket: WebSocketLike | undefined;
+    try {
+      try {
+        socket = factory(url, {
+          headers:
+            options.apiKey === undefined || options.apiKey === ''
+              ? {}
+              : { 'X-Api-Key': options.apiKey },
+        });
+      } catch (error) {
+        throw new WebSocketConnectionError('WebSocket connection failed', {
+          cause: error,
+        });
+      }
+      const events = socketEvents(socket);
+      await waitForOpen(events, options.connectTimeoutMs, options.signal);
+      let awaitingNextUpdate = false;
+      while (true) {
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+          throw new DoclingTimeoutError(options.taskId, timeoutMs);
+        }
+        const event = await withTimeout(
+          events.next(),
+          remaining,
+          options.signal,
+          () => new DoclingTimeoutError(options.taskId, timeoutMs)
+        );
+        if (event.done) {
+          throw new WebSocketConnectionError(
+            'WebSocket status stream ended unexpectedly'
+          );
+        }
+        if (event.value.kind === 'error') {
+          throw new WebSocketConnectionError(
+            `WebSocket status stream failed: ${
+              event.value.error instanceof Error
+                ? event.value.error.message
+                : String(event.value.error ?? 'unknown error')
+            }`
+          );
+        }
+        if (event.value.kind === 'close') {
+          if (awaitingNextUpdate && isCleanWebSocketClose(event.value)) {
+            return;
+          }
+          throw new WebSocketConnectionError(
+            `WebSocket status stream closed before a terminal status: ${`${event.value.code ?? 0} ${event.value.reason ?? ''}`.trim()}`
+          );
+        }
+        if (event.value.kind !== 'message') {
+          continue;
+        }
+
+        awaitingNextUpdate = false;
+        const envelope = parseEnvelope(event.value.data, options.parseStatus);
+        if (envelope.error !== undefined && envelope.error !== null) {
+          if (envelope.error === 'Task not found.') {
+            throw new DoclingTaskNotFoundError(options.taskId);
+          }
+          throw new DoclingServiceUnavailableError('WebSocket status stream failed', {
+            detail: envelope.error,
+          });
+        }
+        if (envelope.task === undefined) {
+          continue;
+        }
+        await options.onStatus?.(envelope.task);
+        yield envelope.task;
+        if (isTerminal(envelope.task)) {
+          return;
+        }
+        if (envelope.message === 'update') {
+          try {
+            socket.send('next');
+          } catch (error) {
+            if (isCleanWebSocketClose(error)) {
+              return;
+            }
+            throw new WebSocketConnectionError(
+              'WebSocket status stream could not request the next update',
+              { cause: error }
+            );
+          }
+          awaitingNextUpdate = true;
+        }
+      }
+    } catch (error) {
+      if (
+        error instanceof DoclingTimeoutError ||
+        error instanceof DoclingTaskNotFoundError ||
+        options.signal?.aborted === true
+      ) {
+        throw error;
+      }
+      if (!(error instanceof WebSocketConnectionError)) {
+        throw error;
+      }
+      const remaining = deadline - Date.now();
+      if (attempt >= 3 || remaining <= 0) {
+        throw new DoclingServiceUnavailableError(
+          'WebSocket status stream is unavailable',
+          {
+            detail: error instanceof Error ? error.message : String(error),
+            cause: error,
+          }
+        );
+      }
+      await (options.sleep ?? abortableDelay)(
+        Math.min(1_000 * 2 ** attempt, remaining),
+        options.signal
+      );
+    } finally {
+      try {
+        socket?.close();
+      } catch {
+        // Best-effort cleanup; the originating watcher error remains authoritative.
+      }
+    }
+  }
+}
+
+function webSocketUrl(baseUrl: string, taskId: string, apiKey?: string): string {
+  const url = new URL(baseUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/v1/status/ws/${encodeURIComponent(
+    taskId
+  )}`;
+  if (apiKey !== undefined && apiKey !== '') {
+    url.searchParams.set('api_key', apiKey);
+  }
+  return url.toString();
+}
+
+function socketEvents(socket: WebSocketLike): AsyncGenerator<SocketEvent> {
+  const queue: SocketEvent[] = [];
+  const waiters: Array<(event: SocketEvent) => void> = [];
+  const push = (event: SocketEvent) => {
+    const waiter = waiters.shift();
+    if (waiter === undefined) {
+      queue.push(event);
+    } else {
+      waiter(event);
+    }
+  };
+  socket.addEventListener('open', () => push({ kind: 'open' }));
+  socket.addEventListener('message', event =>
+    push({ kind: 'message', data: event.data })
+  );
+  socket.addEventListener('error', event =>
+    push({ kind: 'error', error: event.error ?? event.message })
+  );
+  socket.addEventListener('close', event =>
+    push({
+      kind: 'close',
+      code: event.code ?? 0,
+      reason: event.reason ?? '',
+      wasClean: event.wasClean ?? false,
+    })
+  );
+
+  return (async function* () {
+    while (true) {
+      if (queue.length > 0) {
+        const event = queue.shift();
+        if (event !== undefined) {
+          yield event;
+        }
+        continue;
+      }
+      yield await new Promise<SocketEvent>(resolve => waiters.push(resolve));
+    }
+  })();
+}
+
+async function waitForOpen(
+  events: AsyncGenerator<SocketEvent>,
+  timeoutMs: number,
+  signal?: AbortSignal
+): Promise<void> {
+  const event = await withTimeout(
+    events.next(),
+    timeoutMs,
+    signal,
+    () => new WebSocketConnectionError(`WebSocket connection exceeded ${timeoutMs} ms`)
+  );
+  if (event.done || event.value.kind !== 'open') {
+    throw new WebSocketConnectionError('WebSocket connection failed before opening');
+  }
+}
+
+class WebSocketConnectionError extends Error {}
+
+function isCleanWebSocketClose(value: unknown): boolean {
+  if (value instanceof Error && value.name === 'ConnectionClosedOK') {
+    return true;
+  }
+  return (
+    isRecord(value) &&
+    (value.wasClean === true || value.code === 1000 || value.closeCode === 1000)
+  );
+}
+
+function parseEnvelope(
+  data: unknown,
+  parseStatus: (value: unknown) => TaskStatusResponse
+): WebSocketEnvelope {
+  let value: unknown;
+  try {
+    const text =
+      typeof data === 'string'
+        ? data
+        : data instanceof ArrayBuffer
+          ? new TextDecoder().decode(data)
+          : ArrayBuffer.isView(data)
+            ? new TextDecoder().decode(data)
+            : String(data);
+    value = JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new DoclingServiceUnavailableError(
+      'WebSocket returned an invalid JSON envelope',
+      { cause: error }
+    );
+  }
+  if (
+    !isRecord(value) ||
+    !['connection', 'update', 'error'].includes(String(value.message))
+  ) {
+    throw new DoclingServiceUnavailableError(
+      'WebSocket returned an invalid status envelope'
+    );
+  }
+  return {
+    message: value.message as WebSocketEnvelope['message'],
+    ...(value.task === undefined ? {} : { task: parseStatus(value.task) }),
+    ...(typeof value.error === 'string' || value.error === null
+      ? { error: value.error }
+      : {}),
+  };
+}
+
+function isTerminal(status: TaskStatusResponse): boolean {
+  return ['success', 'failure'].includes(status.task_status);
+}
+
+function validateWatchTimes(
+  timeoutMs: number,
+  serverWaitSeconds: number,
+  pollIntervalMs: number
+): void {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new DoclingProtocolError('timeoutMs must be a positive number');
+  }
+  if (!Number.isFinite(serverWaitSeconds) || serverWaitSeconds < 0) {
+    throw new DoclingProtocolError('serverWaitSeconds must be non-negative');
+  }
+  if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 0) {
+    throw new DoclingProtocolError('pollIntervalMs must be non-negative');
+  }
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  milliseconds: number,
+  signal: AbortSignal | undefined,
+  error: () => Error
+): Promise<T> {
+  if (signal?.aborted === true) {
+    throw signal.reason;
+  }
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(error()), milliseconds);
+    const abort = () => reject(signal?.reason);
+    signal?.addEventListener('abort', abort, { once: true });
+    promise.then(
+      value => {
+        clearTimeout(timeout);
+        signal?.removeEventListener('abort', abort);
+        resolve(value);
+      },
+      reason => {
+        clearTimeout(timeout);
+        signal?.removeEventListener('abort', abort);
+        reject(reason);
+      }
+    );
+  });
+}
+
+function abortableDelay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  if (milliseconds <= 0) {
+    return Promise.resolve();
+  }
+  if (signal?.aborted === true) {
+    return Promise.reject(signal.reason);
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', abort);
+      resolve();
+    }, milliseconds);
+    const abort = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/docling-client/test/artifacts.test.ts
+++ b/docling-client/test/artifacts.test.ts
@@ -1,0 +1,363 @@
+import { strToU8, zipSync } from 'fflate';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  ArtifactDownloader,
+  DoclingArtifactDownloadError,
+  documentFromBundle,
+  materializePresignedResult,
+  selectDocumentArtifact,
+  type PresignedUrlConvertResponse,
+} from '../src';
+
+const INPUT = {
+  filename: 'manual.pdf',
+  source: 'https://example.test/manual.pdf',
+} as const;
+
+describe('presigned artifact materialization', () => {
+  it('prefers a resource bundle and embeds referenced images', async () => {
+    const document = {
+      schema_name: 'DoclingDocument',
+      name: 'manual',
+      pictures: [
+        {
+          image: {
+            mimetype: 'image/png',
+            dpi: 144,
+            size: { width: 1, height: 1 },
+            uri: 'artifacts/picture.png',
+          },
+        },
+      ],
+      pages: {
+        '1': {
+          image: {
+            mimetype: 'image/png',
+            dpi: 72,
+            size: { width: 1, height: 1 },
+            uri: './artifacts/page.png',
+          },
+        },
+      },
+    };
+    const bundle = zipSync({
+      'manual.json': strToU8(JSON.stringify(document)),
+      'artifacts/picture.png': new Uint8Array([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      ]),
+      'artifacts/page.png': new Uint8Array([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      ]),
+    });
+    const fetchImplementation = vi.fn(
+      async () => new Response(Uint8Array.from(bundle).buffer)
+    );
+    const downloader = new ArtifactDownloader({
+      fetch: fetchImplementation,
+      resolver: async () => ['8.8.8.8'],
+    });
+    const response = presignedResponse([
+      {
+        artifact_type: 'json',
+        mime_type: 'application/json',
+        uri: 'https://artifacts.example.test/manual.json',
+      },
+      {
+        artifact_type: 'resource_bundle',
+        mime_type: 'application/zip',
+        uri: 'https://artifacts.example.test/manual.zip',
+      },
+    ]);
+
+    const result = await materializePresignedResult<Record<string, unknown>>(
+      response,
+      INPUT,
+      downloader
+    );
+
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      'https://artifacts.example.test/manual.zip',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+    const materialized = result.document as typeof document;
+    expect(materialized.pictures[0]?.image.uri).toBe(
+      'data:image/png;base64,iVBORw0KGgo='
+    );
+    expect(materialized.pages['1']?.image.uri).toBe(
+      'data:image/png;base64,iVBORw0KGgo='
+    );
+    expect(result.processing_time).toBe(2.5);
+  });
+
+  it('materializes JSON-only results and preserves server metadata', async () => {
+    const downloader = new ArtifactDownloader({
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            schema_name: 'DoclingDocument',
+            name: 'manual',
+          })
+        ),
+      resolver: async () => ['8.8.8.8'],
+    });
+    const response = presignedResponse([
+      {
+        artifact_type: 'json',
+        mime_type: 'application/json',
+        uri: 'https://artifacts.example.test/manual.json',
+      },
+    ]);
+    response.documents[0]!.timings = {
+      conversion: { scope: 'document', count: 1, times: [1.2] },
+    };
+    response.documents[0]!.confidence = { parse_score: 0.9 };
+
+    const result = await materializePresignedResult<Record<string, unknown>>(
+      response,
+      INPUT,
+      downloader
+    );
+
+    expect(result.document).toMatchObject({
+      schema_name: 'DoclingDocument',
+      name: 'manual',
+    });
+    expect(result.timings).toHaveProperty('conversion');
+    expect(result.confidence).toEqual({ parse_score: 0.9 });
+  });
+
+  it('does not download failed document items and degrades reconstruction errors', async () => {
+    const fetchImplementation = vi.fn();
+    const downloader = new ArtifactDownloader({
+      fetch: fetchImplementation,
+      resolver: async () => ['8.8.8.8'],
+    });
+    const failed = presignedResponse([]);
+    failed.documents[0]!.status = 'failure';
+    failed.documents[0]!.errors = [
+      {
+        component_type: 'document_backend',
+        module_name: 'parser',
+        error_message: 'encrypted',
+      },
+    ];
+
+    const failedResult = await materializePresignedResult(failed, INPUT, downloader);
+    expect(failedResult.status).toBe('failure');
+    expect(failedResult.errors[0]?.error_message).toBe('encrypted');
+    expect(fetchImplementation).not.toHaveBeenCalled();
+
+    const missingArtifacts = presignedResponse([]);
+    const degraded = await materializePresignedResult(
+      missingArtifacts,
+      INPUT,
+      downloader
+    );
+    expect(degraded.status).toBe('failure');
+    expect(degraded.errors[0]?.error_message).toContain(
+      "neither a 'json' nor a 'resource_bundle'"
+    );
+  });
+
+  it('rejects unsafe ZIP member and image-reference paths', () => {
+    expect(() =>
+      documentFromBundle(
+        zipSync({
+          '../secret.json': strToU8('{}'),
+        })
+      )
+    ).toThrow('unsafe path');
+
+    const escapingImage = {
+      schema_name: 'DoclingDocument',
+      name: 'manual',
+      pictures: [
+        {
+          image: {
+            mimetype: 'image/png',
+            dpi: 72,
+            size: {},
+            uri: '../../secret.png',
+          },
+        },
+      ],
+    };
+    expect(() =>
+      documentFromBundle(
+        zipSync({
+          'manual.json': strToU8(JSON.stringify(escapingImage)),
+        })
+      )
+    ).toThrow('unsafe path');
+  });
+
+  it('requires exactly one Docling JSON and validates referenced image bytes', () => {
+    expect(() =>
+      documentFromBundle(
+        zipSync({
+          'one.json': strToU8(
+            JSON.stringify({ schema_name: 'DoclingDocument', name: 'one' })
+          ),
+          'two.json': strToU8(
+            JSON.stringify({ schema_name: 'DoclingDocument', name: 'two' })
+          ),
+        })
+      )
+    ).toThrow('exactly one');
+
+    const document = {
+      schema_name: 'DoclingDocument',
+      name: 'manual',
+      pictures: [
+        {
+          image: {
+            mimetype: 'image/png',
+            dpi: 72,
+            size: {},
+            uri: 'artifacts/fake.png',
+          },
+        },
+      ],
+    };
+    expect(() =>
+      documentFromBundle(
+        zipSync({
+          'manual.json': strToU8(JSON.stringify(document)),
+          'artifacts/fake.png': strToU8('<script>not an image</script>'),
+        })
+      )
+    ).toThrow('do not match image/png');
+  });
+
+  it('selects bundles independent of artifact order', () => {
+    const item = presignedResponse([
+      {
+        artifact_type: 'json',
+        mime_type: 'application/json',
+        uri: 'https://example.test/document.json',
+      },
+      {
+        artifact_type: 'resource_bundle',
+        mime_type: 'application/zip',
+        uri: 'https://example.test/document.zip',
+      },
+    ]).documents[0]!;
+
+    expect(selectDocumentArtifact(item).artifact_type).toBe('resource_bundle');
+  });
+});
+
+describe('artifact download security', () => {
+  it('rejects private and mixed DNS answers and accepts all-public answers', async () => {
+    const fetchImplementation = vi.fn(async () => new Response('artifact'));
+    const privateDownloader = new ArtifactDownloader({
+      fetch: fetchImplementation,
+      resolver: async () => ['127.0.0.1'],
+    });
+    await expect(
+      privateDownloader.download('https://artifacts.example.test/a')
+    ).rejects.toBeInstanceOf(DoclingArtifactDownloadError);
+
+    const mixedDownloader = new ArtifactDownloader({
+      fetch: fetchImplementation,
+      resolver: async () => ['8.8.8.8', '10.0.0.1'],
+    });
+    await expect(
+      mixedDownloader.download('https://artifacts.example.test/a')
+    ).rejects.toThrow('globally routable');
+
+    const publicDownloader = new ArtifactDownloader({
+      fetch: fetchImplementation,
+      resolver: async () => ['8.8.8.8', '2606:4700:4700::1111'],
+    });
+    await expect(
+      publicDownloader.download('https://artifacts.example.test/a')
+    ).resolves.toEqual(strToU8('artifact'));
+  });
+
+  it('revalidates redirect destinations and never forwards service headers', async () => {
+    const fetchImplementation = vi.fn().mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'http://127.0.0.1/private' },
+      })
+    );
+    const downloader = new ArtifactDownloader({
+      fetch: fetchImplementation,
+      resolver: async () => ['8.8.8.8'],
+    });
+
+    await expect(
+      downloader.download('https://artifacts.example.test/start')
+    ).rejects.toThrow('globally routable');
+    expect(fetchImplementation).toHaveBeenCalledTimes(1);
+    expect(fetchImplementation.mock.calls[0]?.[1]).not.toHaveProperty('headers');
+  });
+
+  it('supports an explicit private-host override and enforces streamed size limits', async () => {
+    const allowed = new ArtifactDownloader({
+      allowPrivateUrls: true,
+      fetch: async () => new Response(new Uint8Array([1, 2, 3])),
+      maxBytes: 3,
+    });
+    await expect(allowed.download('http://127.0.0.1/a')).resolves.toEqual(
+      new Uint8Array([1, 2, 3])
+    );
+
+    const rejected = new ArtifactDownloader({
+      allowPrivateUrls: true,
+      fetch: async () => new Response(new Uint8Array([1, 2, 3, 4])),
+      maxBytes: 3,
+    });
+    await expect(rejected.download('http://127.0.0.1/a')).rejects.toThrow(
+      'byte download limit'
+    );
+  });
+
+  it('requires redirect locations and caps redirect count', async () => {
+    const missingLocation = new ArtifactDownloader({
+      allowPrivateUrls: true,
+      fetch: async () => new Response(null, { status: 302 }),
+    });
+    await expect(
+      missingLocation.download('https://example.test/start')
+    ).rejects.toThrow('missing Location');
+
+    const looping = new ArtifactDownloader({
+      allowPrivateUrls: true,
+      maxRedirects: 1,
+      fetch: async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: '/again' },
+        }),
+    });
+    await expect(looping.download('https://example.test/start')).rejects.toThrow(
+      'exceeded 1 redirects'
+    );
+  });
+});
+
+function presignedResponse(
+  artifacts: PresignedUrlConvertResponse['documents'][number]['artifacts']
+): PresignedUrlConvertResponse {
+  return {
+    num_converted: 1,
+    num_succeeded: 1,
+    num_partially_succeeded: 0,
+    num_failed: 0,
+    processing_time: 2.5,
+    documents: [
+      {
+        source_index: 0,
+        source_uri: 'https://example.test/manual.pdf',
+        filename: 'manual.pdf',
+        status: 'success',
+        errors: [],
+        timings: {},
+        artifacts,
+      },
+    ],
+  };
+}

--- a/docling-client/test/client.test.ts
+++ b/docling-client/test/client.test.ts
@@ -1,0 +1,1346 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ArtifactDownloader,
+  DoclingClient,
+  DoclingConversionError,
+  DoclingHttpError,
+  DoclingProtocolError,
+  DoclingResponseSchemaMismatchError,
+  DoclingResultExpiredError,
+  DoclingResultNotReadyError,
+  DoclingServiceError,
+  DoclingTaskError,
+  DoclingTaskNotFoundError,
+  type DoclingBinaryResponse,
+  type DoclingTransport,
+  type DoclingTransportRequest,
+  type SubmitTarget,
+  type TaskStatusResponse,
+} from '../src';
+
+class ScriptedTransport implements DoclingTransport {
+  readonly requests: DoclingTransportRequest[] = [];
+  readonly #responses: unknown[];
+
+  constructor(...responses: unknown[]) {
+    this.#responses = responses;
+  }
+
+  async request<T>(request: DoclingTransportRequest): Promise<T> {
+    this.requests.push(request);
+    if (this.#responses.length === 0) {
+      throw new Error('No scripted response remains');
+    }
+    const response = this.#responses.shift();
+    if (response instanceof Error) {
+      throw response;
+    }
+    return response as T;
+  }
+}
+
+class FunctionTransport implements DoclingTransport {
+  readonly requests: DoclingTransportRequest[] = [];
+  readonly #handler: (request: DoclingTransportRequest) => Promise<unknown>;
+
+  constructor(
+    handler: (request: DoclingTransportRequest) => Promise<unknown> | unknown
+  ) {
+    this.#handler = async request => handler(request);
+  }
+
+  async request<T>(request: DoclingTransportRequest): Promise<T> {
+    this.requests.push(request);
+    return (await this.#handler(request)) as T;
+  }
+}
+
+function task(
+  taskId: string,
+  taskStatus: TaskStatusResponse['task_status'],
+  taskType: TaskStatusResponse['task_type'] = 'convert',
+  extra: Partial<TaskStatusResponse> = {}
+): TaskStatusResponse {
+  return {
+    task_id: taskId,
+    task_type: taskType,
+    task_status: taskStatus,
+    ...extra,
+  };
+}
+
+function documentResponse(
+  filename: string,
+  text = '# Manual'
+): Record<string, unknown> {
+  return {
+    status: 'success',
+    processing_time: 1.25,
+    timings: {},
+    errors: [],
+    document: {
+      filename,
+      md_content: text,
+      json_content: {
+        schema_name: 'DoclingDocument',
+        name: filename.replace(/\.pdf$/i, ''),
+      },
+    },
+  };
+}
+
+function clientWith(
+  transport: DoclingTransport,
+  options: Partial<ConstructorParameters<typeof DoclingClient>[0]> = {}
+): DoclingClient<Record<string, unknown>> {
+  return new DoclingClient<Record<string, unknown>>({
+    baseUrl: 'https://docling.example.test',
+    statusWatcher: 'polling',
+    transport,
+    ...options,
+  });
+}
+
+describe('conversion submission and targets', () => {
+  it('keeps source-fetch headers separate from service request headers', async () => {
+    const transport = new ScriptedTransport(task('convert-1', 'pending'));
+    const client = clientWith(transport, {
+      apiKey: 'base-key',
+      headers: { 'X-Request-Id': 'request-1' },
+    });
+
+    const job = await client.submitUrl(
+      'https://files.example.test/manual.pdf',
+      {
+        to_formats: ['md'],
+        do_ocr: true,
+      },
+      {
+        target: { kind: 'inbody' },
+        sourceHeaders: { authorization: 'Bearer source-token' },
+        headers: {
+          authorization: 'Bearer service-token',
+          'x-api-key': 'override-key',
+        },
+      }
+    );
+
+    expect(job.taskId).toBe('convert-1');
+    expect(transport.requests).toEqual([
+      {
+        method: 'POST',
+        url: 'https://docling.example.test/v1/convert/source/async',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          authorization: 'Bearer service-token',
+          'x-api-key': 'override-key',
+          'x-request-id': 'request-1',
+        },
+        body: {
+          options: {
+            to_formats: ['md', 'json'],
+            do_ocr: true,
+          },
+          sources: [
+            {
+              kind: 'http',
+              url: 'https://files.example.test/manual.pdf',
+              headers: { authorization: 'Bearer source-token' },
+            },
+          ],
+          target: { kind: 'inbody' },
+          callbacks: [],
+        },
+      },
+    ]);
+  });
+
+  it('tries presigned output by default and narrowly falls back to in-body', async () => {
+    const transport = new ScriptedTransport(
+      new DoclingHttpError({
+        method: 'POST',
+        url: 'https://docling.example.test/v1/convert/source/async',
+        status: 422,
+        body: {
+          detail:
+            "validation error: target.kind input should be 'inbody', not presigned_url",
+        },
+      }),
+      task('fallback-1', 'pending')
+    );
+    const client = clientWith(transport);
+
+    await client.submitUrl('https://files.example.test/manual.pdf');
+
+    expect(
+      transport.requests.map(
+        request => (request.body as { target: { kind: string } }).target.kind
+      )
+    ).toEqual(['presigned_url', 'inbody']);
+    expect(
+      (
+        transport.requests[1]?.body as {
+          options: { to_formats: string[] };
+        }
+      ).options.to_formats
+    ).toContain('json');
+  });
+
+  it('does not hide unrelated presigned-target submission errors', async () => {
+    const error = new DoclingHttpError({
+      method: 'POST',
+      url: 'https://docling.example.test/v1/convert/source/async',
+      status: 422,
+      body: { detail: 'invalid OCR configuration' },
+    });
+    const transport = new ScriptedTransport(error);
+    const client = clientWith(transport);
+
+    await expect(
+      client.submitUrl('https://files.example.test/manual.pdf')
+    ).rejects.toBe(error);
+    expect(transport.requests).toHaveLength(1);
+  });
+
+  it('decodes in-body, ZIP, presigned, and storage-target results by target', async () => {
+    const binary: DoclingBinaryResponse = {
+      content: new Uint8Array([0, 255, 80, 75]),
+      contentType: 'application/zip',
+      headers: {
+        'content-disposition': 'attachment; filename="converted_docs.zip"',
+      },
+    };
+    const presigned = {
+      num_converted: 1,
+      num_succeeded: 1,
+      num_partially_succeeded: 0,
+      num_failed: 0,
+      processing_time: 2,
+      documents: [],
+    };
+    const counts = {
+      num_converted: 5,
+      num_succeeded: 5,
+      num_partially_succeeded: 0,
+      num_failed: 0,
+      processing_time: 4,
+    };
+    const transport = new ScriptedTransport(
+      task('inline', 'success'),
+      documentResponse('inline.pdf'),
+      task('zip', 'success'),
+      binary,
+      task('presigned', 'success'),
+      presigned,
+      task('storage', 'success'),
+      counts
+    );
+    const client = clientWith(transport);
+
+    const inline = await (
+      await client.submitUrl(
+        'https://example.test/inline.pdf',
+        {},
+        {
+          target: { kind: 'inbody' },
+        }
+      )
+    ).result();
+    const archive = await (
+      await client.submitUrl(
+        'https://example.test/archive.pdf',
+        {},
+        {
+          target: { kind: 'zip' },
+        }
+      )
+    ).result();
+    const artifactResult = await (
+      await client.submitUrl(
+        'https://example.test/presigned.pdf',
+        {},
+        {
+          target: { kind: 'presigned_url' },
+        }
+      )
+    ).result();
+    const remote = await (
+      await client.submitUrl(
+        'https://example.test/storage.pdf',
+        {},
+        {
+          target: {
+            kind: 's3',
+            endpoint: 's3.example.test',
+            access_key: 'access',
+            secret_key: 'secret',
+            bucket: 'out',
+          },
+        }
+      )
+    ).result();
+
+    expect(inline.input.filename).toBe('inline.pdf');
+    expect(inline.document).toMatchObject({
+      schema_name: 'DoclingDocument',
+      name: 'inline',
+    });
+    expect([...archive.content]).toEqual([0, 255, 80, 75]);
+    expect(archive.filename).toBe('converted_docs.zip');
+    expect(artifactResult).toEqual(presigned);
+    expect(remote).toEqual(counts);
+  });
+
+  it.each([
+    {
+      kind: 'put',
+      url: 'https://storage.example.test/result',
+    },
+    {
+      kind: 'azure_blob',
+      account_name: 'account',
+      container: 'output',
+      connection_string: 'azure-secret',
+    },
+    {
+      kind: 'google_cloud_storage',
+      bucket: 'output',
+      service_account_key: {
+        project_id: 'project',
+        private_key_id: 'key-id',
+        private_key: 'private-secret',
+        client_email: 'client@example.test',
+        client_id: 'client-id',
+        auth_uri: 'https://accounts.example.test/auth',
+        token_uri: 'https://accounts.example.test/token',
+        auth_provider_x509_cert_url: 'https://accounts.example.test/certs',
+        client_x509_cert_url: 'https://accounts.example.test/client-cert',
+        universe_domain: 'googleapis.com',
+      },
+    },
+    {
+      kind: 'google_drive',
+      path_id: 'folder-id',
+      refresh_token: 'refresh-secret',
+      credentials: {
+        client_id: 'client-id',
+        project_id: 'project',
+        auth_uri: 'https://accounts.example.test/auth',
+        token_uri: 'https://accounts.example.test/token',
+        auth_provider_x509_cert_url: 'https://accounts.example.test/certs',
+        client_secret: 'client-secret',
+        redirect_uris: ['https://app.example.test/callback'],
+      },
+    },
+  ] satisfies SubmitTarget[])(
+    'passes the $kind target contract and plaintext credentials unchanged',
+    async target => {
+      const counts = {
+        num_converted: 1,
+        num_succeeded: 1,
+        num_partially_succeeded: 0,
+        num_failed: 0,
+        processing_time: 1,
+      };
+      const transport = new ScriptedTransport(
+        task(`target-${target.kind}`, 'success'),
+        counts
+      );
+      const client = clientWith(transport);
+
+      await (
+        await client.submitUrl(
+          'https://example.test/manual.pdf',
+          {},
+          {
+            target,
+          }
+        )
+      ).result();
+
+      expect((transport.requests[0]?.body as { target: unknown }).target).toEqual(
+        target
+      );
+    }
+  );
+
+  it('uploads binary content through the multipart file endpoint', async () => {
+    const transport = new ScriptedTransport(task('multipart', 'pending'));
+    const client = clientWith(transport);
+
+    await client.submitBinary(
+      {
+        filename: 'manual.pdf',
+        contentType: 'application/pdf',
+        data: new Uint8Array([1, 2, 3]),
+      },
+      {
+        options: {
+          do_ocr: false,
+          ocr_custom_config: { kind: 'custom', threshold: 0.8 },
+        },
+        target: { kind: 'zip' },
+      }
+    );
+
+    const request = transport.requests[0];
+    expect(request?.url).toBe('https://docling.example.test/v1/convert/file/async');
+    expect(request?.bodyType).toBe('form');
+    expect(request?.headers['content-type']).toBeUndefined();
+    const form = request?.body as FormData;
+    expect(form.get('do_ocr')).toBe('false');
+    expect(form.get('ocr_custom_config')).toBe('{"kind":"custom","threshold":0.8}');
+    expect(form.get('target_type')).toBe('zip');
+    expect((form.get('files') as File).name).toBe('manual.pdf');
+  });
+
+  it('accepts a local Node path and rejects unsupported or ZIP URLs', async () => {
+    const transport = new ScriptedTransport(task('path', 'pending'));
+    const client = clientWith(transport);
+
+    await client.submitSource('/tmp/docling-ts-work/docling-client/README.md', {
+      target: { kind: 'inbody' },
+    });
+    expect(transport.requests[0]?.url).toContain('/v1/convert/file/async');
+    expect(((transport.requests[0]?.body as FormData).get('files') as File).name).toBe(
+      'README.md'
+    );
+
+    await expect(client.submitSource('ftp://example.test/manual.pdf')).rejects.toThrow(
+      'Unsupported document source URL scheme'
+    );
+    await expect(
+      client.submitSource('https://example.test/archive.ZIP?download=1')
+    ).rejects.toThrow('ZIP URLs are not accepted');
+  });
+
+  it('allows optional option fields to clear client defaults without mutation', async () => {
+    const defaults = {
+      do_ocr: true,
+      ocr_custom_config: { kind: 'default', language: 'en' },
+    };
+    const overrides = {
+      ocr_custom_config: null,
+    };
+    const transport = new ScriptedTransport(task('cleared', 'pending'));
+    const client = clientWith(transport, { options: defaults });
+
+    await client.submitUrl('https://example.test/manual.pdf', overrides, {
+      target: { kind: 'inbody' },
+    });
+
+    expect(
+      (transport.requests[0]?.body as { options: Record<string, unknown> }).options
+    ).toEqual({
+      do_ocr: true,
+      to_formats: ['md', 'json'],
+    });
+    expect(defaults).toEqual({
+      do_ocr: true,
+      ocr_custom_config: { kind: 'default', language: 'en' },
+    });
+    expect(overrides).toEqual({ ocr_custom_config: null });
+  });
+});
+
+describe('chunk and batch requests', () => {
+  it('converts and chunks with full chunk options and converted document output', async () => {
+    const chunkResult = {
+      processing_time: 2.5,
+      chunks: [
+        {
+          filename: 'manual.pdf',
+          chunk_index: 0,
+          text: '# Install\nConnect power.',
+          doc_items: ['#/texts/0'],
+        },
+      ],
+      documents: [],
+    };
+    const transport = new ScriptedTransport(
+      task('chunk-1', 'success', 'chunk'),
+      chunkResult
+    );
+    const client = clientWith(transport);
+
+    const result = await (
+      await client.submitChunkUrl(
+        'https://files.example.test/manual.pdf',
+        {
+          chunker: 'hybrid',
+          convert_options: { do_ocr: true },
+          chunking_options: {
+            max_tokens: 384,
+            include_raw_text: true,
+            merge_peers: false,
+          },
+          include_converted_doc: true,
+          callbacks: [
+            {
+              url: 'https://workflow.example.test/progress',
+              headers: { authorization: 'Bearer callback-token' },
+            },
+          ],
+        },
+        {
+          sourceHeaders: { authorization: 'Bearer source-token' },
+        }
+      )
+    ).result();
+
+    expect(result).toEqual(chunkResult);
+    expect(transport.requests[0]?.body).toEqual({
+      convert_options: { do_ocr: true },
+      chunking_options: {
+        chunker: 'hybrid',
+        max_tokens: 384,
+        include_raw_text: true,
+        merge_peers: false,
+      },
+      sources: [
+        {
+          kind: 'http',
+          url: 'https://files.example.test/manual.pdf',
+          headers: { authorization: 'Bearer source-token' },
+        },
+      ],
+      include_converted_doc: true,
+      target: { kind: 'inbody' },
+      callbacks: [
+        {
+          url: 'https://workflow.example.test/progress',
+          headers: { authorization: 'Bearer callback-token' },
+        },
+      ],
+    });
+  });
+
+  it('uses the multipart hierarchical chunk endpoint for binary input', async () => {
+    const transport = new ScriptedTransport(task('chunk-file', 'pending', 'chunk'));
+    const client = clientWith(transport);
+
+    await client.submitChunkBinary(
+      {
+        filename: 'manual.pdf',
+        data: new Uint8Array([1, 2, 3]),
+      },
+      {
+        chunker: 'hierarchical',
+        chunking_options: { use_markdown_tables: true },
+        include_converted_doc: true,
+      }
+    );
+
+    const request = transport.requests[0];
+    expect(request?.url).toContain('/v1/chunk/hierarchical/file/async');
+    const form = request?.body as FormData;
+    expect(form.get('chunking_use_markdown_tables')).toBe('true');
+    expect(form.get('include_converted_doc')).toBe('true');
+  });
+
+  it('submits batch connector requests and preserves generic secret fields', async () => {
+    const counts = {
+      num_converted: 2,
+      num_succeeded: 2,
+      num_partially_succeeded: 0,
+      num_failed: 0,
+      processing_time: 3,
+    };
+    const transport = new ScriptedTransport(task('batch-1', 'success'), counts);
+    const client = clientWith(transport);
+
+    const result = await (
+      await client.submitBatch({
+        sources: [
+          { kind: 'http', url: 'https://example.test/a.pdf' },
+          {
+            kind: 'filenet',
+            repository_id: 'OS1',
+            api_key: 'source-secret',
+          },
+        ],
+        target: {
+          kind: 'plugin_artifact_store',
+          bucket: 'out',
+          api_key: 'target-secret',
+        },
+        callbacks: [{ url: 'https://workflow.example.test/batch' }],
+      })
+    ).result();
+
+    expect(result).toEqual(counts);
+    expect(transport.requests[0]?.url).toContain('/v1/convert/source/batch');
+    expect(transport.requests[0]?.body).toMatchObject({
+      sources: [{ kind: 'http' }, { kind: 'filenet', api_key: 'source-secret' }],
+      target: {
+        kind: 'plugin_artifact_store',
+        api_key: 'target-secret',
+      },
+      callbacks: [{ url: 'https://workflow.example.test/batch' }],
+    });
+  });
+
+  it('rejects malformed known batch connectors instead of treating them as generic', async () => {
+    const client = clientWith(new ScriptedTransport());
+
+    await expect(
+      client.submitBatch({
+        sources: [
+          {
+            kind: 's3',
+            bucket: 'input',
+          } as never,
+        ],
+        target: { kind: 'presigned_url' },
+      })
+    ).rejects.toThrow('s3 source requires endpoint');
+
+    await expect(
+      client.submitBatch({
+        sources: [{ kind: 'http', url: 'https://example.test/manual.pdf' }],
+        target: {
+          kind: 'google_drive',
+          path_id: 'folder',
+        } as never,
+      })
+    ).rejects.toThrow('requires token_path or refresh_token');
+  });
+});
+
+describe('high-level conversion, limits, and concurrency', () => {
+  it('merges client defaults shallowly, caps page range, and materializes inline JSON', async () => {
+    const transport = new ScriptedTransport(
+      new DoclingHttpError({
+        method: 'POST',
+        url: 'https://docling.example.test/v1/convert/source/async',
+        status: 400,
+        body: { detail: 'artifact storage to be configured' },
+      }),
+      task('convert-high', 'success'),
+      documentResponse('manual.pdf')
+    );
+    const client = clientWith(transport, {
+      options: {
+        do_ocr: true,
+        page_range: [2, 100],
+        ocr_custom_config: { kind: 'default', language: 'en' },
+      },
+    });
+
+    const result = await client.convert('https://example.test/manual.pdf', {
+      options: {
+        ocr_custom_config: { kind: 'replacement' },
+      },
+      maxNumPages: 10,
+    });
+
+    expect(result.document?.schema_name).toBe('DoclingDocument');
+    expect(result.input.filename).toBe('manual.pdf');
+    const fallbackBody = transport.requests[1]?.body as {
+      options: Record<string, unknown>;
+    };
+    expect(fallbackBody.options).toMatchObject({
+      do_ocr: true,
+      page_range: [2, 10],
+      ocr_custom_config: { kind: 'replacement' },
+      to_formats: ['md', 'json'],
+    });
+  });
+
+  it('skips known oversized input without making a request', async () => {
+    const transport = new ScriptedTransport();
+    const client = clientWith(transport);
+
+    const result = await client.convert(
+      {
+        kind: 'file',
+        filename: 'large.pdf',
+        base64_string: 'AQIDBA==',
+      },
+      {
+        maxFileSize: 3,
+        raisesOnError: false,
+      }
+    );
+
+    expect(result.status).toBe('skipped');
+    expect(result.errors[0]?.category).toBe('policy');
+    expect(transport.requests).toHaveLength(0);
+  });
+
+  it('raises for failed high-level conversion unless disabled', async () => {
+    const failure = {
+      ...documentResponse('bad.pdf'),
+      status: 'failure',
+      errors: [
+        {
+          component_type: 'document_backend',
+          module_name: 'parser',
+          error_message: 'encrypted',
+        },
+      ],
+    };
+    const transport = new ScriptedTransport(
+      new DoclingHttpError({
+        method: 'POST',
+        url: 'https://docling.example.test/v1/convert/source/async',
+        status: 400,
+        body: { detail: 'artifact storage to be configured' },
+      }),
+      task('bad-1', 'success'),
+      failure,
+      new DoclingHttpError({
+        method: 'POST',
+        url: 'https://docling.example.test/v1/convert/source/async',
+        status: 400,
+        body: { detail: 'artifact storage to be configured' },
+      }),
+      task('bad-2', 'success'),
+      failure
+    );
+    const client = clientWith(transport);
+
+    await expect(
+      client.convert(
+        { kind: 'http', url: 'https://example.test/bad.pdf' },
+        {
+          options: {},
+          raisesOnError: true,
+        }
+      )
+    ).rejects.toBeInstanceOf(DoclingConversionError);
+
+    const returned = await client.convert(
+      { kind: 'http', url: 'https://example.test/bad.pdf' },
+      { raisesOnError: false }
+    );
+    expect(returned.status).toBe('failure');
+  });
+
+  it('streams bounded fan-out in completion order or input order', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    const transport = new FunctionTransport(async request => {
+      if (request.url.includes('/convert/source/async')) {
+        const url = (request.body as { sources: Array<{ url: string }> }).sources[0]
+          ?.url;
+        return task(url?.includes('slow') === true ? 'slow' : 'fast', 'pending');
+      }
+      if (request.url.includes('/status/poll/')) {
+        const slow = request.url.includes('slow');
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        await new Promise(resolve => setTimeout(resolve, slow ? 20 : 1));
+        active -= 1;
+        return task(slow ? 'slow' : 'fast', 'success');
+      }
+      return {
+        num_converted: 1,
+        num_succeeded: 1,
+        num_partially_succeeded: 0,
+        num_failed: 0,
+        processing_time: 1,
+        documents: [],
+      };
+    });
+    const client = clientWith(transport, { maxConcurrency: 2 });
+    const items = [
+      { source: { kind: 'http' as const, url: 'https://example.test/slow.pdf' } },
+      { source: { kind: 'http' as const, url: 'https://example.test/fast.pdf' } },
+    ];
+
+    const completionOrder: string[] = [];
+    for await (const [item] of client.submitAndRetrieveEach(items, {
+      maxInFlight: 2,
+      ordered: false,
+    })) {
+      completionOrder.push((item.source as { url: string }).url);
+    }
+    const ordered: string[] = [];
+    for await (const [item] of client.submitAndRetrieveEach(items, {
+      maxInFlight: 2,
+      ordered: true,
+    })) {
+      ordered.push((item.source as { url: string }).url);
+    }
+
+    expect(completionOrder).toEqual([
+      'https://example.test/fast.pdf',
+      'https://example.test/slow.pdf',
+    ]);
+    expect(ordered).toEqual([
+      'https://example.test/slow.pdf',
+      'https://example.test/fast.pdf',
+    ]);
+    expect(maximumActive).toBeLessThanOrEqual(2);
+  });
+
+  it('convertAll submits one task per source and preserves ordered failures', async () => {
+    const transport = new FunctionTransport(request => {
+      if (request.url.includes('/convert/source/async')) {
+        const body = request.body as {
+          target: { kind: string };
+          sources: Array<{ url: string }>;
+        };
+        if (body.target.kind === 'presigned_url') {
+          throw new DoclingHttpError({
+            method: 'POST',
+            url: request.url,
+            status: 400,
+            body: { detail: 'artifact storage to be configured' },
+          });
+        }
+        const filename = new URL(body.sources[0]!.url).pathname.split('/').at(-1)!;
+        return task(filename, 'success');
+      }
+      const taskId = request.url.split('/').at(-1)!;
+      return documentResponse(taskId);
+    });
+    const client = clientWith(transport);
+
+    const results = [];
+    for await (const result of client.convertAll(
+      [
+        'ftp://example.test/unsupported.pdf',
+        'https://example.test/one.pdf',
+        'https://example.test/two.pdf',
+      ],
+      { maxConcurrency: 2 }
+    )) {
+      results.push(result);
+    }
+
+    expect(results.map(result => result.status)).toEqual([
+      'failure',
+      'success',
+      'success',
+    ]);
+    expect(results.map(result => result.input.filename)).toEqual([
+      'unsupported.pdf',
+      'one.pdf',
+      'two.pdf',
+    ]);
+    expect(
+      transport.requests.filter(request =>
+        request.url.includes('/convert/source/async')
+      )
+    ).toHaveLength(4);
+  });
+
+  it('materializes the default presigned result for high-level conversion', async () => {
+    const presigned = {
+      num_converted: 1,
+      num_succeeded: 1,
+      num_partially_succeeded: 0,
+      num_failed: 0,
+      processing_time: 2,
+      documents: [
+        {
+          source_index: 0,
+          source_uri: 'https://example.test/manual.pdf',
+          filename: 'manual.pdf',
+          status: 'success',
+          errors: [],
+          timings: {},
+          artifacts: [
+            {
+              artifact_type: 'json',
+              mime_type: 'application/json',
+              uri: 'https://artifacts.example.test/manual.json',
+            },
+          ],
+        },
+      ],
+    };
+    const transport = new ScriptedTransport(
+      task('presigned-high', 'success'),
+      presigned
+    );
+    const artifactDownloader = new ArtifactDownloader({
+      resolver: async () => ['8.8.8.8'],
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            schema_name: 'DoclingDocument',
+            name: 'manual',
+          })
+        ),
+    });
+    const client = clientWith(transport, { artifactDownloader });
+
+    const result = await client.convert('https://example.test/manual.pdf');
+
+    expect(result.document).toEqual({
+      schema_name: 'DoclingDocument',
+      name: 'manual',
+    });
+    expect(result.input.source).toBe('https://example.test/manual.pdf');
+  });
+});
+
+describe('task and result lifecycle', () => {
+  it('always includes wait=0 and maps poll 404 to task-not-found', async () => {
+    const transport = new ScriptedTransport(
+      new DoclingHttpError({
+        method: 'GET',
+        url: 'https://docling.example.test/v1/status/poll/missing?wait=0',
+        status: 404,
+        body: { detail: 'Task not found.' },
+      })
+    );
+    const client = clientWith(transport);
+
+    await expect(client.poll('missing')).rejects.toBeInstanceOf(
+      DoclingTaskNotFoundError
+    );
+    expect(transport.requests[0]?.url).toContain('?wait=0');
+  });
+
+  it('maps result not-ready, expired, unknown-task, and terminal failure states', async () => {
+    const notReady = () =>
+      new DoclingHttpError({
+        method: 'GET',
+        url: 'https://docling.example.test/v1/result/task',
+        status: 404,
+        body: {
+          detail: 'Task result not found. Please wait for a completion status.',
+        },
+      });
+    const unknown = new DoclingHttpError({
+      method: 'GET',
+      url: 'https://docling.example.test/v1/result/task',
+      status: 404,
+      body: { detail: 'Task not found.' },
+    });
+    const transport = new ScriptedTransport(notReady(), notReady(), unknown, {
+      kind: 'TaskFailureResult',
+      failure: {
+        category: 'backend_failure',
+        message: 'authoritative failure',
+        retryable: false,
+        phase: 'execution',
+        details: {},
+      },
+    });
+    const client = clientWith(transport);
+
+    await expect(client.getResult('pending')).rejects.toBeInstanceOf(
+      DoclingResultNotReadyError
+    );
+    await expect(
+      client.getResult('expired', {
+        lastStatus: task('expired', 'success'),
+      })
+    ).rejects.toBeInstanceOf(DoclingResultExpiredError);
+    await expect(client.getResult('unknown')).rejects.toBeInstanceOf(
+      DoclingTaskNotFoundError
+    );
+    await expect(
+      client.getResult('failed', {
+        lastStatus: task('failed', 'failure'),
+      })
+    ).rejects.toMatchObject({
+      name: 'DoclingTaskError',
+      message: 'authoritative failure',
+    });
+  });
+
+  it('fetches authoritative result details even when the cached job status failed', async () => {
+    const transport = new ScriptedTransport(task('failed-job', 'failure'), {
+      kind: 'TaskFailureResult',
+      failure: {
+        category: 'backend_failure',
+        message: 'document is encrypted',
+        retryable: false,
+        phase: 'execution',
+        details: {},
+      },
+    });
+    const client = clientWith(transport);
+    const job = await client.submitUrl(
+      'https://example.test/bad.pdf',
+      {},
+      {
+        target: { kind: 'inbody' },
+      }
+    );
+
+    await expect(job.result()).rejects.toBeInstanceOf(DoclingTaskError);
+    expect(transport.requests[1]?.url).toContain('/v1/result/failed-job');
+  });
+
+  it('uses zero retries for health and version', async () => {
+    const transport = new ScriptedTransport({ status: 'ok' }, { version: '1.0.0' });
+    const client = clientWith(transport);
+
+    await client.health();
+    await client.version();
+
+    expect(transport.requests.map(request => request.retries)).toEqual([0, 0]);
+  });
+
+  it('validates health and nested result schemas', async () => {
+    const healthClient = clientWith(new ScriptedTransport({}));
+    await expect(healthClient.health()).resolves.toEqual({ status: 'ok' });
+
+    const invalidHealth = clientWith(new ScriptedTransport({ status: 42 }));
+    await expect(invalidHealth.health()).rejects.toBeInstanceOf(
+      DoclingResponseSchemaMismatchError
+    );
+
+    const validConfidence = clientWith(
+      new ScriptedTransport({
+        ...documentResponse('manual.pdf'),
+        confidence: {
+          parse_score: 0.92,
+          layout_score: null,
+          mean_grade: 'good',
+          low_grade: 'fair',
+        },
+      })
+    );
+    await expect(validConfidence.getResult('valid-confidence')).resolves.toMatchObject({
+      confidence: {
+        parse_score: 0.92,
+        layout_score: null,
+        mean_grade: 'good',
+        low_grade: 'fair',
+      },
+    });
+
+    const invalidConfidence = clientWith(
+      new ScriptedTransport({
+        ...documentResponse('manual.pdf'),
+        confidence: { mean_grade: 'great' },
+      })
+    );
+    await expect(
+      invalidConfidence.getResult('invalid-confidence')
+    ).rejects.toBeInstanceOf(DoclingResponseSchemaMismatchError);
+
+    const invalidResult = clientWith(
+      new ScriptedTransport({
+        ...documentResponse('manual.pdf'),
+        errors: [
+          {
+            component_type: 'made_up',
+            module_name: 'test',
+            error_message: 'bad wire data',
+          },
+        ],
+      })
+    );
+    await expect(invalidResult.getResult('invalid')).rejects.toBeInstanceOf(
+      DoclingResponseSchemaMismatchError
+    );
+  });
+
+  it('maps unexpected result 404s to the common service error', async () => {
+    const client = clientWith(
+      new ScriptedTransport(
+        new DoclingHttpError({
+          method: 'GET',
+          url: 'https://docling.example.test/v1/result/task',
+          status: 404,
+          body: { detail: 'unexpected lookup response' },
+        })
+      )
+    );
+    const error = await client.getResult('task').catch(value => value);
+    expect(error).toBeInstanceOf(DoclingServiceError);
+    expect(error).toMatchObject({
+      message: 'Unexpected result lookup error',
+      status: 404,
+      detail: 'unexpected lookup response',
+    });
+  });
+
+  it('watches an already-terminal attached job and closes idempotently', async () => {
+    let closeCalls = 0;
+    const transport: DoclingTransport = {
+      request: async () => task('terminal', 'success') as never,
+      close: () => {
+        closeCalls += 1;
+      },
+    };
+    const client = clientWith(transport);
+    const job = client.job('terminal', task('terminal', 'success'));
+    const updates: string[] = [];
+    for await (const status of job.watch({ statusWatcher: 'polling' })) {
+      updates.push(status.task_status);
+    }
+    expect(updates).toEqual(['success']);
+
+    await client.close();
+    await client.close();
+    expect(closeCalls).toBe(1);
+    await expect(client.health()).rejects.toBeInstanceOf(DoclingProtocolError);
+  });
+});
+
+describe('parity edge cases', () => {
+  it('preserves external target configuration for binary inputs via unified JSON', async () => {
+    const transport = new ScriptedTransport(task('binary-s3', 'pending'));
+    const client = clientWith(transport);
+    const target: SubmitTarget = {
+      kind: 's3',
+      endpoint: 's3.example.test',
+      access_key: 'access',
+      secret_key: 'secret',
+      bucket: 'converted',
+      key_prefix: 'out/',
+    };
+
+    await client.submitBinary(
+      {
+        data: new Uint8Array([1, 2, 3]),
+        filename: 'manual.pdf',
+        contentType: 'application/pdf',
+      },
+      { target }
+    );
+
+    expect(transport.requests[0]?.url).toContain('/v1/convert/source/async');
+    expect(transport.requests[0]?.body).toMatchObject({
+      sources: [
+        {
+          kind: 'file',
+          filename: 'manual.pdf',
+          base64_string: 'AQID',
+        },
+      ],
+      target,
+    });
+  });
+
+  it('applies batch outputFormats and rejects malformed connector/callback shapes', async () => {
+    const transport = new ScriptedTransport(task('batch', 'pending'));
+    const client = clientWith(transport, { options: { do_ocr: true } });
+    await client.submitBatch(
+      {
+        sources: [{ kind: 'http', url: 'https://example.test/a.pdf' }],
+        target: { kind: 'presigned_url' },
+      },
+      { outputFormats: ['json'] }
+    );
+    expect(transport.requests[0]?.body).toMatchObject({
+      options: { do_ocr: true, to_formats: ['json'] },
+    });
+
+    await expect(
+      client.submitBatch({
+        sources: [{ kind: 'http', url: 'ftp://example.test/a.pdf' }],
+        target: { kind: 'presigned_url' },
+      })
+    ).rejects.toBeInstanceOf(DoclingProtocolError);
+    await expect(
+      client.submitBatch({
+        sources: [{ kind: 'http', url: 'https://example.test/a.pdf' }],
+        target: { kind: 'presigned_url' },
+        callbacks: [
+          {
+            url: 'https://callback.example.test',
+            headers: { authorization: 42 } as never,
+          },
+        ],
+      })
+    ).rejects.toBeInstanceOf(DoclingProtocolError);
+  });
+
+  it('propagates pre-aborted convertAll cancellation and isolates malformed URLs', async () => {
+    const client = clientWith(new ScriptedTransport());
+    const controller = new AbortController();
+    const reason = new Error('stop batch');
+    controller.abort(reason);
+    await expect(
+      collectAsync(
+        client.convertAll(['https://example.test/a.pdf'], {
+          signal: controller.signal,
+        })
+      )
+    ).rejects.toBe(reason);
+
+    const results = await collectAsync(
+      client.convertAll([
+        { kind: 'http', url: 'not a URL' },
+        'ftp://example.test/also-invalid.pdf',
+      ] as never)
+    );
+    expect(results.map(result => result.status)).toEqual(['failure', 'failure']);
+  });
+
+  it('supports includeConvertedDoc on the Python-shaped chunk overload', async () => {
+    const transport = new ScriptedTransport(task('chunk', 'success', 'chunk'), {
+      chunks: [],
+      documents: [],
+      processing_time: 0,
+    });
+    const client = clientWith(transport);
+    await client.chunk(
+      'https://example.test/manual.pdf',
+      'hybrid',
+      {},
+      {
+        includeConvertedDoc: true,
+      }
+    );
+    expect(transport.requests[0]?.body).toMatchObject({
+      include_converted_doc: true,
+    });
+  });
+
+  it('validates nested conversion and chunk options before submission', async () => {
+    expect(() =>
+      clientWith(new ScriptedTransport(), {
+        options: {
+          picture_description_local: { repo_id: 'local-model' },
+          picture_description_api: {
+            url: 'https://models.example.test',
+          },
+        },
+      })
+    ).toThrow(DoclingProtocolError);
+    expect(() =>
+      clientWith(new ScriptedTransport(), {
+        options: {
+          picture_description_local: {
+            repo_id: 'local-model',
+            classification_allow: ['not-a-docling-label'],
+          } as never,
+        },
+      })
+    ).toThrow(DoclingProtocolError);
+    expect(() =>
+      clientWith(new ScriptedTransport(), {
+        options: {
+          vlm_pipeline_model_local: {
+            repo_id: 'model',
+            response_format: 'doctags',
+            inference_framework: 'not-a-framework',
+          } as never,
+        },
+      })
+    ).toThrow(DoclingProtocolError);
+
+    const transport = new ScriptedTransport(task('chunk-options', 'pending', 'chunk'));
+    const client = clientWith(transport);
+    await expect(
+      client.submitChunk({
+        chunker: 'hybrid',
+        sources: [{ kind: 'http', url: 'https://example.test/manual.pdf' }],
+        chunking_options: { merge_peers: 'yes' } as never,
+      })
+    ).rejects.toBeInstanceOf(DoclingProtocolError);
+
+    await client.submitChunk({
+      chunker: 'hybrid',
+      sources: [{ kind: 'http', url: 'https://example.test/manual.pdf' }],
+      chunking_options: { chunker: 'hierarchical' } as never,
+    });
+    expect(transport.requests[0]?.body).toMatchObject({
+      chunking_options: { chunker: 'hybrid' },
+    });
+  });
+
+  it('fills Python response defaults in cached task metadata and failures', async () => {
+    const transport = new ScriptedTransport({
+      task_id: 'normalized-status',
+      task_type: 'convert',
+      task_status: 'pending',
+      task_meta: { num_docs: 2 },
+      failure: {
+        category: 'unknown',
+        message: 'not terminal',
+        retryable: false,
+        phase: 'orchestration',
+      },
+    });
+    const client = clientWith(transport);
+    const job = await client.submitUrl(
+      'https://example.test/manual.pdf',
+      {},
+      { target: { kind: 'inbody' } }
+    );
+
+    expect(job.status.task_meta).toEqual({
+      num_docs: 2,
+      num_processed: 0,
+      num_succeeded: 0,
+      num_partially_succeeded: 0,
+      num_failed: 0,
+    });
+    expect(job.status.failure?.details).toEqual({});
+  });
+
+  it('preserves raw JSON-labeled binary bytes and annotates schema errors', async () => {
+    const bytes = new TextEncoder().encode('{not-json');
+    const binaryClient = clientWith(
+      new ScriptedTransport({
+        content: bytes,
+        contentType: 'application/json',
+        headers: {},
+      } satisfies DoclingBinaryResponse)
+    );
+    await expect(binaryClient.getBinaryResult('raw')).resolves.toMatchObject({
+      content: bytes,
+      content_type: 'application/json',
+    });
+
+    const schemaClient = clientWith(new ScriptedTransport({ unexpected: 'response' }));
+    await expect(schemaClient.getResult('schema')).rejects.toMatchObject({
+      name: 'DoclingResponseSchemaMismatchError',
+      status: 200,
+    });
+  });
+
+  it('cancels source normalization before and during binary materialization', async () => {
+    const transport = new ScriptedTransport();
+    const client = clientWith(transport);
+    const preAborted = new AbortController();
+    preAborted.abort('stop before reading');
+    await expect(
+      client.submitSource('/path/that/must/not/be/read.pdf', {
+        signal: preAborted.signal,
+        target: { kind: 'inbody' },
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    class SlowBlob extends Blob {
+      override async arrayBuffer(): Promise<ArrayBuffer> {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        return super.arrayBuffer();
+      }
+    }
+    const duringRead = new AbortController();
+    const reason = new Error('stop while materializing');
+    const submission = client.submitBinary(
+      {
+        data: new SlowBlob(['document']),
+        filename: 'manual.pdf',
+      },
+      {
+        signal: duringRead.signal,
+        target: {
+          kind: 's3',
+          endpoint: 's3.example.test',
+          access_key: 'key',
+          secret_key: 'secret',
+          bucket: 'documents',
+        },
+      }
+    );
+    duringRead.abort(reason);
+    await expect(submission).rejects.toBe(reason);
+    expect(transport.requests).toHaveLength(0);
+  });
+});
+
+async function collectAsync<T>(values: AsyncIterable<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const value of values) {
+    results.push(value);
+  }
+  return results;
+}

--- a/docling-client/test/transport.test.ts
+++ b/docling-client/test/transport.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DoclingHttpError,
+  DoclingServiceError,
+  DoclingServiceUnavailableError,
+  FetchTransport,
+  type DoclingBinaryResponse,
+} from '../src';
+
+const REQUEST = {
+  method: 'POST' as const,
+  url: 'https://docling.example.test/v1/convert/source/async',
+  headers: { 'content-type': 'application/json' },
+  body: {},
+};
+
+describe('FetchTransport retry policy', () => {
+  it('retries 500/502 responses for POST with exponential backoff', async () => {
+    const fetchImplementation = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ detail: 'one' }, 500))
+      .mockResolvedValueOnce(jsonResponse({ detail: 'two' }, 502))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }, 200));
+    const delays: number[] = [];
+    const transport = new FetchTransport({
+      fetch: fetchImplementation,
+      retries: 3,
+      backoffBaseMs: 1_000,
+      sleep: async milliseconds => {
+        delays.push(milliseconds);
+      },
+    });
+
+    await expect(transport.request(REQUEST)).resolves.toEqual({ ok: true });
+    expect(delays).toEqual([1_000, 2_000]);
+    expect(fetchImplementation).toHaveBeenCalledTimes(3);
+  });
+
+  it('honors Retry-After only when it is valid', async () => {
+    const retriedFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ detail: 'busy' }, 503, { 'retry-after': '1.5' })
+      )
+      .mockResolvedValueOnce(jsonResponse({ ok: true }, 200));
+    const delays: number[] = [];
+    const retried = new FetchTransport({
+      fetch: retriedFetch,
+      sleep: async milliseconds => {
+        delays.push(milliseconds);
+      },
+    });
+
+    await retried.request(REQUEST);
+    expect(delays).toEqual([1_500]);
+    expect(retriedFetch).toHaveBeenCalledTimes(2);
+
+    const notRetriedFetch = vi.fn(async () => jsonResponse({ detail: 'busy' }, 503));
+    const notRetried = new FetchTransport({
+      fetch: notRetriedFetch,
+      sleep: async () => undefined,
+    });
+    await expect(notRetried.request(REQUEST)).rejects.toMatchObject({
+      name: 'DoclingServiceUnavailableError',
+      status: 503,
+      detail: 'busy',
+    });
+    expect(notRetriedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves exhausted retry detail and ignores blank Retry-After', async () => {
+    const exhausted = new FetchTransport({
+      fetch: async () => jsonResponse({ detail: 'still broken' }, 500),
+      retries: 1,
+      sleep: async () => undefined,
+    });
+    await expect(exhausted.request(REQUEST)).rejects.toMatchObject({
+      name: 'DoclingServiceUnavailableError',
+      status: 500,
+      detail: 'still broken',
+    });
+
+    const blank = vi.fn(async () =>
+      jsonResponse({ detail: 'slow down' }, 429, { 'retry-after': '   ' })
+    );
+    await expect(
+      new FetchTransport({ fetch: blank }).request(REQUEST)
+    ).rejects.toMatchObject({ status: 429 });
+    expect(blank).toHaveBeenCalledTimes(1);
+
+    const exhaustedRateLimit = new FetchTransport({
+      fetch: async () =>
+        jsonResponse({ detail: 'rate limit remains exhausted' }, 429, {
+          'retry-after': '0',
+        }),
+      retries: 1,
+      sleep: async () => undefined,
+    });
+    await expect(exhaustedRateLimit.request(REQUEST)).rejects.toMatchObject({
+      name: 'DoclingServiceUnavailableError',
+      status: 429,
+      detail: 'rate limit remains exhausted',
+    });
+  });
+
+  it('does not call sleep for a zero Retry-After delay', async () => {
+    const sleep = vi.fn(async () => undefined);
+    const fetchImplementation = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ detail: 'busy' }, 503, { 'retry-after': '0' })
+      )
+      .mockResolvedValueOnce(jsonResponse({ ok: true }, 200));
+    await new FetchTransport({ fetch: fetchImplementation, sleep }).request(REQUEST);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('retries network failures only for idempotent methods', async () => {
+    const getFetch = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('socket closed'))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }, 200));
+    const getTransport = new FetchTransport({
+      fetch: getFetch,
+      backoffBaseMs: 1,
+      sleep: async () => undefined,
+    });
+    await expect(
+      getTransport.request({
+        ...REQUEST,
+        method: 'GET',
+        body: undefined,
+      })
+    ).resolves.toEqual({ ok: true });
+    expect(getFetch).toHaveBeenCalledTimes(2);
+
+    const postFetch = vi.fn(async () => {
+      throw new TypeError('socket closed');
+    });
+    const postTransport = new FetchTransport({
+      fetch: postFetch,
+      sleep: async () => undefined,
+    });
+    await expect(postTransport.request(REQUEST)).rejects.toBeInstanceOf(
+      DoclingServiceUnavailableError
+    );
+    expect(postFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a caller abort', async () => {
+    const fetchImplementation = vi.fn(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(init.signal?.reason));
+        });
+      }
+    );
+    const transport = new FetchTransport({
+      fetch: fetchImplementation,
+      sleep: async () => undefined,
+    });
+    const controller = new AbortController();
+    const request = transport.request({
+      ...REQUEST,
+      method: 'GET',
+      signal: controller.signal,
+    });
+    const reason = new Error('caller cancelled');
+    controller.abort(reason);
+
+    await expect(request).rejects.toBe(reason);
+    expect(fetchImplementation).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('FetchTransport response handling', () => {
+  it('maps valid and malformed quota responses to the quota error', async () => {
+    const valid = new FetchTransport(async () =>
+      jsonResponse(
+        {
+          error: 'usage_limit_exceeded',
+          message: 'quota exhausted',
+          details: { currentUsage: 10, limit: 10 },
+        },
+        402
+      )
+    );
+    await expect(valid.request(REQUEST)).rejects.toMatchObject({
+      name: 'DoclingUsageLimitExceededError',
+      currentUsage: 10,
+      limit: 10,
+      detail: 'quota exhausted',
+    });
+
+    const malformed = new FetchTransport(async () =>
+      jsonResponse({ detail: 'payment required' }, 402)
+    );
+    await expect(malformed.request(REQUEST)).rejects.toMatchObject({
+      name: 'DoclingUsageLimitExceededError',
+      currentUsage: null,
+      limit: null,
+      detail: null,
+    });
+  });
+
+  it('decodes non-200 JSON independently of Content-Type', async () => {
+    const detail = new FetchTransport(
+      async () =>
+        new Response(JSON.stringify({ detail: 'invalid options' }), {
+          status: 422,
+        })
+    );
+    await expect(detail.request(REQUEST)).rejects.toMatchObject({
+      name: 'DoclingHttpError',
+      status: 422,
+      detail: 'invalid options',
+    });
+
+    const quota = new FetchTransport(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: 'usage_limit_exceeded',
+            message: 'quota exhausted',
+            details: { currentUsage: 10, limit: 10 },
+          }),
+          { status: 402 }
+        )
+    );
+    await expect(quota.request(REQUEST)).rejects.toMatchObject({
+      name: 'DoclingUsageLimitExceededError',
+      status: 402,
+      detail: 'quota exhausted',
+      currentUsage: 10,
+      limit: 10,
+    });
+  });
+
+  it('preserves HTTP classification when an error body contains malformed JSON', async () => {
+    const malformedJson = (status: number, headers: Record<string, string> = {}) =>
+      new Response('{not-json', {
+        status,
+        headers: { 'content-type': 'application/json', ...headers },
+      });
+
+    await expect(
+      new FetchTransport(async () => malformedJson(422)).request(REQUEST)
+    ).rejects.toMatchObject({
+      name: 'DoclingHttpError',
+      status: 422,
+      detail: null,
+    });
+    await expect(
+      new FetchTransport(async () => malformedJson(402)).request(REQUEST)
+    ).rejects.toMatchObject({
+      name: 'DoclingUsageLimitExceededError',
+      status: 402,
+      detail: null,
+      currentUsage: null,
+      limit: null,
+    });
+    await expect(
+      new FetchTransport({
+        fetch: async () => malformedJson(500),
+        retries: 0,
+      }).request(REQUEST)
+    ).rejects.toMatchObject({
+      name: 'DoclingServiceUnavailableError',
+      status: 500,
+      detail: null,
+    });
+    await expect(
+      new FetchTransport({
+        fetch: async () => malformedJson(429, { 'retry-after': '0' }),
+        retries: 0,
+      }).request(REQUEST)
+    ).rejects.toMatchObject({
+      name: 'DoclingServiceUnavailableError',
+      status: 429,
+      detail: null,
+    });
+  });
+
+  it('uses one service-error hierarchy and requires exact HTTP 200', async () => {
+    const transport = new FetchTransport(async () =>
+      jsonResponse({ accepted: true }, 202)
+    );
+    const error = await transport.request(REQUEST).catch(value => value);
+    expect(error).toBeInstanceOf(DoclingHttpError);
+    expect(error).toBeInstanceOf(DoclingServiceError);
+    expect(error).toMatchObject({ status: 202 });
+  });
+
+  it('preserves response headers on HTTP errors', async () => {
+    const transport = new FetchTransport(async () =>
+      jsonResponse({ detail: 'invalid options' }, 422, { 'x-request-id': 'request-1' })
+    );
+
+    const error = await transport.request(REQUEST).catch(value => value);
+    expect(error).toBeInstanceOf(DoclingHttpError);
+    expect(error).toMatchObject({
+      status: 422,
+      detail: 'invalid options',
+      headers: { 'x-request-id': 'request-1' },
+    });
+  });
+
+  it('preserves status for empty HTTP error bodies', async () => {
+    const transport = new FetchTransport(
+      async () => new Response(null, { status: 404 })
+    );
+    await expect(transport.request(REQUEST)).rejects.toMatchObject({
+      name: 'DoclingHttpError',
+      status: 404,
+      detail: null,
+    });
+  });
+
+  it('returns binary data without text decoding', async () => {
+    const transport = new FetchTransport(
+      async () =>
+        new Response(new Uint8Array([0, 255, 128, 80, 75]), {
+          status: 200,
+          headers: {
+            'content-type': 'application/zip',
+            'content-disposition': 'attachment; filename="result.zip"',
+          },
+        })
+    );
+
+    const response = await transport.request<DoclingBinaryResponse>({
+      ...REQUEST,
+      method: 'GET',
+      body: undefined,
+      responseType: 'bytes',
+    });
+
+    expect([...response.content]).toEqual([0, 255, 128, 80, 75]);
+    expect(response.contentType).toBe('application/zip');
+    expect(response.headers['content-disposition']).toContain('result.zip');
+  });
+
+  it('retries client-owned GET timeouts but not timed-out POST submissions', async () => {
+    const hangingFetch = vi.fn(
+      async (_input: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('aborted', 'AbortError'))
+          );
+        })
+    );
+    const transport = new FetchTransport({
+      fetch: hangingFetch,
+      retries: 1,
+      timeoutMs: 2,
+      backoffBaseMs: 1,
+      sleep: async () => undefined,
+    });
+
+    await expect(
+      transport.request({
+        ...REQUEST,
+        method: 'GET',
+        body: undefined,
+      })
+    ).rejects.toBeInstanceOf(DoclingServiceUnavailableError);
+    expect(hangingFetch).toHaveBeenCalledTimes(2);
+
+    hangingFetch.mockClear();
+    await expect(transport.request(REQUEST)).rejects.toBeInstanceOf(
+      DoclingServiceUnavailableError
+    );
+    expect(hangingFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+function jsonResponse(
+  body: unknown,
+  status: number,
+  headers: Record<string, string> = {}
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+  });
+}

--- a/docling-client/test/type-parity.ts
+++ b/docling-client/test/type-parity.ts
@@ -1,0 +1,86 @@
+import {
+  type AutoSubmitResult,
+  type ConfidenceScores,
+  type DoclingComponentType,
+  DoclingClient,
+  type DoclingJob,
+  type ConversionItem,
+  type ConversionResult,
+  type ConvertDocumentsOptions,
+  type FailureCategory,
+  type InBodyTarget,
+  type PictureClassificationLabel,
+  type PresignedUrlConvertResponse,
+  type ProfilingScope,
+  type QualityGrade,
+} from '../src';
+
+export function compileTimeParity(client: DoclingClient): unknown[] {
+  const auto = client.submitUrl('https://example.test/manual.pdf');
+  const autoCheck: Promise<DoclingJob<AutoSubmitResult>> = auto;
+
+  const inBody = client.submitUrl(
+    'https://example.test/manual.pdf',
+    {},
+    { target: { kind: 'inbody' } satisfies InBodyTarget }
+  );
+  const inBodyCheck: Promise<DoclingJob<ConversionResult>> = inBody;
+
+  const presigned = client.submitFile(
+    'ZmlsZQ==',
+    'manual.pdf',
+    {},
+    {
+      target: { kind: 'presigned_url' },
+    }
+  );
+  const presignedCheck: Promise<DoclingJob<PresignedUrlConvertResponse>> = presigned;
+
+  const autoFanout: AsyncGenerator<
+    [ConversionItem & { metadata?: unknown }, AutoSubmitResult | Error]
+  > = client.submitAndRetrieveEach([{ source: 'https://example.test/a.pdf' }]);
+
+  const confidence = {
+    parse_score: 0.91,
+    layout_score: null,
+    mean_grade: 'good',
+    low_grade: 'fair',
+  } satisfies ConfidenceScores;
+  const category: FailureCategory = 'backend_failure';
+  const component: DoclingComponentType = 'document_backend';
+  const scope: ProfilingScope = 'document';
+  const grade: QualityGrade = 'excellent';
+  const pictureLabel: PictureClassificationLabel = 'engineering_drawing';
+  const pictureOptions: ConvertDocumentsOptions = {
+    picture_description_local: {
+      repo_id: 'model',
+      classification_allow: [pictureLabel],
+    },
+  };
+
+  // @ts-expect-error Python's wire contract does not accept arbitrary categories.
+  const invalidCategory: FailureCategory = 'made_up';
+  // @ts-expect-error Python's wire contract does not accept arbitrary grades.
+  const invalidGrade: QualityGrade = 'great';
+  // @ts-expect-error Python's wire contract does not accept arbitrary scopes.
+  const invalidScope: ProfilingScope = 'task';
+  // @ts-expect-error Picture labels are the exact Docling Core enum.
+  const invalidPictureLabel: PictureClassificationLabel = 'diagram';
+
+  return [
+    autoCheck,
+    inBodyCheck,
+    presignedCheck,
+    autoFanout,
+    confidence,
+    category,
+    component,
+    scope,
+    grade,
+    invalidCategory,
+    invalidGrade,
+    invalidScope,
+    pictureOptions,
+    invalidPictureLabel,
+  ];
+}

--- a/docling-client/test/watchers.test.ts
+++ b/docling-client/test/watchers.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DoclingTaskNotFoundError,
+  watchTask,
+  type TaskStatusResponse,
+  type WebSocketLike,
+} from '../src';
+
+class FakeSocket implements WebSocketLike {
+  readonly sent: string[] = [];
+  readonly #listeners = new Map<
+    string,
+    Array<(event: Record<string, unknown>) => void>
+  >();
+  readyState = 0;
+  closed = false;
+
+  constructor(onOpen?: (socket: FakeSocket) => void) {
+    queueMicrotask(() => {
+      this.readyState = 1;
+      this.emit('open');
+      onOpen?.(this);
+    });
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = 3;
+  }
+
+  addEventListener(
+    type: 'open' | 'message' | 'error' | 'close',
+    listener: (event: Record<string, unknown>) => void
+  ): void {
+    const listeners = this.#listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.#listeners.set(type, listeners);
+  }
+
+  message(value: unknown): void {
+    this.emit('message', { data: JSON.stringify(value) });
+  }
+
+  error(message: string): void {
+    this.emit('error', { message });
+  }
+
+  disconnect(code = 1006): void {
+    this.emit('close', { code, reason: 'disconnected', wasClean: false });
+  }
+
+  cleanDisconnect(): void {
+    this.emit('close', { code: 1000, reason: 'OK', wasClean: true });
+  }
+
+  private emit(type: string, event: Record<string, unknown> = {}): void {
+    for (const listener of this.#listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+class HangingSocket implements WebSocketLike {
+  readonly readyState = 0;
+  closed = false;
+
+  send(data: string): void {
+    void data;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  addEventListener(
+    type: 'open' | 'message' | 'error' | 'close',
+    listener: (event: Record<string, unknown>) => void
+  ): void {
+    void type;
+    void listener;
+  }
+}
+
+describe('Docling WebSocket watcher', () => {
+  it('yields connection/update frames and sends next only after nonterminal updates', async () => {
+    let socket: FakeSocket | undefined;
+    let openedUrl = '';
+    const statuses: string[] = [];
+    const watcher = watchTask({
+      taskId: 'task/with space',
+      baseUrl: 'https://docling.example.test/prefix',
+      apiKey: 'secret key',
+      watcher: 'websocket',
+      fallbackToPoll: false,
+      connectTimeoutMs: 100,
+      webSocketFactory: url => {
+        openedUrl = url;
+        socket = new FakeSocket(current => {
+          current.message({
+            message: 'connection',
+            task: task('pending'),
+          });
+          current.message({
+            message: 'update',
+            task: task('started'),
+          });
+        });
+        const originalSend = socket.send.bind(socket);
+        socket.send = value => {
+          originalSend(value);
+          socket?.message({
+            message: 'update',
+            task: task('success'),
+          });
+        };
+        return socket;
+      },
+      poll: async () => task('success'),
+      parseStatus,
+    });
+
+    for await (const status of watcher) {
+      statuses.push(status.task_status);
+    }
+
+    expect(openedUrl).toBe(
+      'wss://docling.example.test/prefix/v1/status/ws/task%2Fwith%20space?api_key=secret+key'
+    );
+    expect(statuses).toEqual(['pending', 'started', 'success']);
+    expect(socket?.sent).toEqual(['next']);
+    expect(socket?.closed).toBe(true);
+  });
+
+  it('does not poll-fallback for task-not-found envelopes', async () => {
+    const poll = vi.fn(async () => task('success'));
+    const watcher = watchTask({
+      taskId: 'missing',
+      baseUrl: 'https://docling.example.test',
+      watcher: 'websocket',
+      fallbackToPoll: true,
+      connectTimeoutMs: 100,
+      webSocketFactory: () =>
+        new FakeSocket(socket => {
+          socket.message({
+            message: 'error',
+            error: 'Task not found.',
+          });
+        }),
+      poll,
+      parseStatus,
+    });
+
+    await expect(collect(watcher)).rejects.toBeInstanceOf(DoclingTaskNotFoundError);
+    expect(poll).not.toHaveBeenCalled();
+  });
+
+  it('falls back to long polling after a service WebSocket error', async () => {
+    const poll = vi.fn(async () => task('success'));
+    const sockets: FakeSocket[] = [];
+    const factory = vi.fn(() => {
+      const socket = new FakeSocket(current => {
+        current.message({
+          message: 'error',
+          error: 'Server is busy',
+        });
+      });
+      sockets.push(socket);
+      return socket;
+    });
+    const watcher = watchTask({
+      taskId: 'fallback',
+      baseUrl: 'http://docling.example.test',
+      watcher: 'websocket',
+      fallbackToPoll: true,
+      connectTimeoutMs: 100,
+      webSocketFactory: factory,
+      poll,
+      parseStatus,
+      sleep: async () => undefined,
+      pollIntervalMs: 0,
+      serverWaitSeconds: 0,
+    });
+
+    await expect(collect(watcher)).resolves.toEqual(['success']);
+    expect(poll).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(sockets[0]?.closed).toBe(true);
+  });
+
+  it('reconnects after an abnormal close using exponential delays', async () => {
+    let attempts = 0;
+    const delays: number[] = [];
+    const watcher = watchTask({
+      taskId: 'reconnect',
+      baseUrl: 'https://docling.example.test',
+      watcher: 'websocket',
+      fallbackToPoll: false,
+      connectTimeoutMs: 100,
+      webSocketFactory: () => {
+        attempts += 1;
+        return new FakeSocket(socket => {
+          if (attempts === 1) {
+            socket.disconnect();
+          } else {
+            socket.message({ message: 'connection', task: task('success') });
+          }
+        });
+      },
+      poll: async () => task('success'),
+      parseStatus,
+      sleep: async milliseconds => {
+        delays.push(milliseconds);
+      },
+    });
+
+    await expect(collect(watcher)).resolves.toEqual(['success']);
+    expect(attempts).toBe(2);
+    expect(delays).toEqual([1_000]);
+  });
+
+  it('retries connection timeouts before reporting the stream unavailable', async () => {
+    const sockets: HangingSocket[] = [];
+    const delays: number[] = [];
+    const factory = vi.fn(() => {
+      const socket = new HangingSocket();
+      sockets.push(socket);
+      return socket;
+    });
+    const watcher = watchTask({
+      taskId: 'connect-timeout',
+      baseUrl: 'https://docling.example.test',
+      watcher: 'websocket',
+      fallbackToPoll: false,
+      connectTimeoutMs: 1,
+      webSocketFactory: factory,
+      poll: async () => task('success'),
+      parseStatus,
+      sleep: async milliseconds => {
+        delays.push(milliseconds);
+      },
+    });
+
+    await expect(collect(watcher)).rejects.toMatchObject({
+      name: 'DoclingServiceUnavailableError',
+      detail: 'WebSocket connection exceeded 1 ms',
+    });
+    expect(factory).toHaveBeenCalledTimes(4);
+    expect(delays).toEqual([1_000, 2_000, 4_000]);
+    expect(sockets.every(socket => socket.closed)).toBe(true);
+  });
+
+  it('treats a clean close while requesting the next update as end of stream', async () => {
+    const factory = vi.fn(() => {
+      const socket = new FakeSocket(current => {
+        current.message({ message: 'update', task: task('pending') });
+      });
+      socket.send = () => {
+        const error = new Error('received 1000 (OK)');
+        error.name = 'ConnectionClosedOK';
+        throw error;
+      };
+      return socket;
+    });
+    const watcher = watchTask({
+      taskId: 'clean-send-close',
+      baseUrl: 'https://docling.example.test',
+      watcher: 'websocket',
+      fallbackToPoll: false,
+      connectTimeoutMs: 100,
+      webSocketFactory: factory,
+      poll: async () => task('success'),
+      parseStatus,
+    });
+
+    await expect(collect(watcher)).resolves.toEqual(['pending']);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a clean close event after requesting the next update as end of stream', async () => {
+    const factory = vi.fn(() => {
+      const socket = new FakeSocket(current => {
+        current.message({ message: 'update', task: task('pending') });
+      });
+      socket.send = value => {
+        socket.sent.push(value);
+        queueMicrotask(() => {
+          socket.readyState = 3;
+          socket.cleanDisconnect();
+        });
+      };
+      return socket;
+    });
+    const watcher = watchTask({
+      taskId: 'clean-event-close',
+      baseUrl: 'https://docling.example.test',
+      watcher: 'websocket',
+      fallbackToPoll: false,
+      connectTimeoutMs: 100,
+      webSocketFactory: factory,
+      poll: async () => task('success'),
+      parseStatus,
+      sleep: async () => undefined,
+    });
+
+    await expect(collect(watcher)).resolves.toEqual(['pending']);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the socket when the consumer stops early and supplies auth headers', async () => {
+    let socket: FakeSocket | undefined;
+    let factoryOptions: { headers: Readonly<Record<string, string>> } | undefined;
+    const watcher = watchTask({
+      taskId: 'early',
+      baseUrl: 'https://docling.example.test',
+      apiKey: 'secret',
+      watcher: 'websocket',
+      fallbackToPoll: false,
+      connectTimeoutMs: 100,
+      webSocketFactory: (_url, options) => {
+        factoryOptions = options;
+        socket = new FakeSocket(current => {
+          current.message({ message: 'connection', task: task('pending') });
+        });
+        return socket;
+      },
+      poll: async () => task('success'),
+      parseStatus,
+    });
+
+    await watcher.next();
+    await watcher.return(undefined);
+
+    expect(factoryOptions?.headers).toEqual({ 'X-Api-Key': 'secret' });
+    expect(socket?.closed).toBe(true);
+  });
+
+  it('does not reconnect malformed envelopes and closes on callback errors', async () => {
+    const malformedFactory = vi.fn(
+      () =>
+        new FakeSocket(socket => {
+          socket.message({ message: 'not-docling' });
+        })
+    );
+    await expect(
+      collect(
+        watchTask({
+          taskId: 'malformed',
+          baseUrl: 'https://docling.example.test',
+          watcher: 'websocket',
+          fallbackToPoll: false,
+          connectTimeoutMs: 100,
+          webSocketFactory: malformedFactory,
+          poll: async () => task('success'),
+          parseStatus,
+        })
+      )
+    ).rejects.toMatchObject({ name: 'DoclingServiceUnavailableError' });
+    expect(malformedFactory).toHaveBeenCalledTimes(1);
+
+    let callbackSocket: FakeSocket | undefined;
+    const callbackError = new Error('callback failed');
+    await expect(
+      collect(
+        watchTask({
+          taskId: 'callback',
+          baseUrl: 'https://docling.example.test',
+          watcher: 'websocket',
+          fallbackToPoll: true,
+          connectTimeoutMs: 100,
+          webSocketFactory: () => {
+            callbackSocket = new FakeSocket(socket => {
+              socket.message({ message: 'connection', task: task('pending') });
+            });
+            return callbackSocket;
+          },
+          poll: async () => task('success'),
+          parseStatus,
+          onStatus: () => {
+            throw callbackError;
+          },
+        })
+      )
+    ).rejects.toBe(callbackError);
+    expect(callbackSocket?.closed).toBe(true);
+  });
+});
+
+function task(status: TaskStatusResponse['task_status']): TaskStatusResponse {
+  return {
+    task_id: 'task',
+    task_type: 'convert',
+    task_status: status,
+  };
+}
+
+function parseStatus(value: unknown): TaskStatusResponse {
+  return value as TaskStatusResponse;
+}
+
+async function collect(
+  generator: AsyncGenerator<TaskStatusResponse>
+): Promise<string[]> {
+  const statuses: string[] = [];
+  for await (const status of generator) {
+    statuses.push(status.task_status);
+  }
+  return statuses;
+}

--- a/docling-client/tsconfig.json
+++ b/docling-client/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "include": ["src", "test"],
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "rootDir": "."
+  }
+}

--- a/docling-client/tsup.config.ts
+++ b/docling-client/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  clean: true,
+  format: ['cjs', 'esm'],
+  dts: true,
+  sourcemap: true,
+  target: 'es2022',
+});

--- a/docling-client/vitest.config.ts
+++ b/docling-client/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
Adds a [docling-client](docling-client) package, a typescript client for Docling Serve and managed services implementing its API, modeled after the python client. It supports: high-level conversion, bounded multi-document processing, ordinary and batch connectors, every result target, safe presigned-artifact materialization, combined convert-and-chunk jobs, WebSocket and polling task lifecycle, Python-compatible retries and errors, and injectable platform transports.