### PR TITLE
Fix test by changing absolute readme path to relative path.

### DIFF
--- a/docling-client/test/client.test.ts
+++ b/docling-client/test/client.test.ts
@@ -1,3 +1,6 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -400,7 +403,8 @@ describe('conversion submission and targets', () => {
     const transport = new ScriptedTransport(task('path', 'pending'));
     const client = clientWith(transport);
 
-    await client.submitSource('/tmp/docling-ts-work/docling-client/README.md', {
+    const readmePath = join(dirname(fileURLToPath(import.meta.url)), '..', 'README.md');
+    await client.submitSource(readmePath, {
       target: { kind: 'inbody' },
     });
     expect(transport.requests[0]?.url).toContain('/v1/convert/file/async');


### PR DESCRIPTION
It popped up with the first run of the CI.